### PR TITLE
Modified-topology Big Junction Snapshot restoration (Phase 1)

### DIFF
--- a/userscript/src/components/edit-panel/big-junction-props-backup/components/RestoreBigJunctionPropsButton.tsx
+++ b/userscript/src/components/edit-panel/big-junction-props-backup/components/RestoreBigJunctionPropsButton.tsx
@@ -4,6 +4,8 @@ import { useBigJunctionBackupContext } from '../contexts';
 import { BigJunctionDataModel } from '@/@waze/Waze/DataModels/BigJunctionDataModel';
 import { ConditionalTooltip } from '@/components/ConditionalTooltip';
 import { useBigJunctionRestorer } from '../hooks';
+import { createPortal } from 'react-dom';
+import { WzAlert } from '@wazespace/wme-react-components';
 
 interface RestoreBigJunctionPropsButtonProps {
   bigJunction: BigJunctionDataModel;
@@ -15,22 +17,37 @@ export function RestoreBigJunctionPropsButton(
   const backupStrategy = useBigJunctionBackupContext();
   const snapshot = backupStrategy.get();
   const restorer = useBigJunctionRestorer(props.bigJunction, snapshot);
+  const hasRestoredMistmatchingSig =
+    restorer.isRestored && !restorer.isBigJunctionSignatureMatch;
 
   return (
-    <ConditionalTooltip
-      show={restorer.available && !!restorer.restorationUnavailableReason}
-      tooltipContent={t(
-        `jb_utils.big_junction.backup_restore.restoration_disabled_reasons.${restorer?.restorationUnavailableReason}`,
-      )}
-    >
-      <BigJunctionEditPanelButton
-        disabled={
-          !restorer.available || !!restorer.restorationUnavailableReason
-        }
-        onClick={() => restorer.restore()}
+    <>
+      {hasRestoredMistmatchingSig &&
+        createPortal(
+          <WzAlert level="page" variant="warning">
+            {t(
+              'jb_utils.big_junction.backup_restore.mistmatch_signature_snapshot_restored_alert',
+            )}
+          </WzAlert>,
+          document
+            .getElementById('edit-panel')
+            .querySelector('.big-junction .tab-content wz-alerts-group'),
+        )}
+      <ConditionalTooltip
+        show={restorer.available && !!restorer.restorationUnavailableReason}
+        tooltipContent={t(
+          `jb_utils.big_junction.backup_restore.restoration_disabled_reasons.${restorer?.restorationUnavailableReason}`,
+        )}
       >
-        {t('jb_utils.big_junction.actions.restore_props')}
-      </BigJunctionEditPanelButton>
-    </ConditionalTooltip>
+        <BigJunctionEditPanelButton
+          disabled={
+            !restorer.available || !!restorer.restorationUnavailableReason
+          }
+          onClick={() => restorer.restore()}
+        >
+          {t('jb_utils.big_junction.actions.restore_props')}
+        </BigJunctionEditPanelButton>
+      </ConditionalTooltip>
+    </>
   );
 }

--- a/userscript/src/components/edit-panel/big-junction-props-backup/hooks/useBigJunctionRestorer.ts
+++ b/userscript/src/components/edit-panel/big-junction-props-backup/hooks/useBigJunctionRestorer.ts
@@ -1,6 +1,6 @@
 import { BigJunctionDataModel } from '@/@waze/Waze/DataModels/BigJunctionDataModel';
 import { BigJunctionBackupSnapshot } from '../backup-snapshot';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
 import { canUserEditTurnGuidanceForTurn } from '@/utils/wme-entities/turn';
 import { RestoreBigJunctionSnapshotAction } from '../restore-big-junction-snapshot.action';
@@ -10,6 +10,8 @@ export function useBigJunctionRestorer(
   destBigJunction: BigJunctionDataModel,
   backupSnapshot: BigJunctionBackupSnapshot,
 ) {
+  const [isRestored, setIsRestored] = useState(false);
+
   const upgradedLineageSignature = useMemo(
     () => backupSnapshot?.signature?.upgradeSignatureSegmentsLineage?.(),
     [backupSnapshot?.signature],
@@ -52,6 +54,7 @@ export function useBigJunctionRestorer(
     canEditBigJunction,
     canEditTurnGuidance,
     hasTurnsWithGuidance,
+    isRestored,
     restore() {
       getWazeMapEditorWindow().W.model.actionManager.add(
         new RestoreBigJunctionSnapshotAction(
@@ -60,9 +63,9 @@ export function useBigJunctionRestorer(
           backupSnapshot,
         ),
       );
+      setIsRestored(true);
     },
     restorationUnavailableReason: (() => {
-      if (!isBigJunctionSignatureMatch) return 'SIGNATURE_MISMATCH';
       if (!canEditBigJunction) return 'BIG_JUNCTION_EDITING_DISALLOWED';
       if (!canEditTurnGuidance && hasTurnsWithGuidance)
         return 'TURN_GUIDANCE_EDITING_DISALLOWED';

--- a/userscript/src/components/edit-panel/big-junction-props-backup/restore-big-junction-snapshot.action.ts
+++ b/userscript/src/components/edit-panel/big-junction-props-backup/restore-big-junction-snapshot.action.ts
@@ -16,7 +16,9 @@ export class RestoreBigJunctionSnapshotAction extends UpdateBigJunctionAction {
   ) {
     const upgradedSnapshot = updateSnapshotWithSegmentLineage(_snapshot);
     super(dataModel, bigJunction, {
-      turns: upgradedSnapshot.turns,
+      turns: upgradedSnapshot.turns.filter((turn) =>
+        dataModel.turnGraph.hasTurn(turn),
+      ),
       name: upgradedSnapshot.name,
       cityName: upgradedSnapshot.address.city,
       stateName: upgradedSnapshot.address.state,

--- a/userscript/src/resources/localization/en.json
+++ b/userscript/src/resources/localization/en.json
@@ -60,7 +60,8 @@
           "details": "You're about to override a Junction Box backup. This action is irreversible",
           "backup_btn": "OK",
           "ignore_btn": "Ignore"
-        }
+        },
+        "mistmatch_signature_snapshot_restored_alert": "Restored snapshot signature differs from Big Junction signature. Verify newly added turns before saving."
       }
     },
     "save": {


### PR DESCRIPTION
In Phase 1 we ignore added turns, but we do show an alert to the user to be cautious and carefully review the new turns.