### PR TITLE
feat: visualize unverified big junction turns after a backup restoration completed

### DIFF
--- a/userscript/package.json
+++ b/userscript/package.json
@@ -50,7 +50,7 @@
     "@turf/center-of-mass": "^6.5.0",
     "@turf/helpers": "^6.5.0",
     "@turf/transform-scale": "^6.5.0",
-    "@wazespace/wme-react-components": "1.3.0-1",
+    "@wazespace/wme-react-components": "1.3.1-3",
     "axios": "^1.6.8",
     "clsx": "^2.1.0",
     "nanoid": "^3.3.7",

--- a/userscript/pnpm-lock.yaml
+++ b/userscript/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^6.5.0
     version: 6.5.0
   '@wazespace/wme-react-components':
-    specifier: 1.3.0-1
-    version: 1.3.0-1
+    specifier: 1.3.1-3
+    version: 1.3.1-3
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -2451,8 +2451,8 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@wazespace/wme-react-components@1.3.0-1:
-    resolution: {integrity: sha512-68bh28hj8uOnpTjubmD2YPoKQ0hfUlJEBnRYIGD7OKH9APzdA6d4Ay//IciaM3QKykAqhRSchvLLTg3avIos/A==}
+  /@wazespace/wme-react-components@1.3.1-3:
+    resolution: {integrity: sha512-KLVUtNRFeFIdu4Ol6Zx7zSpNmEo2PTjSIOa9se4h552O1SRxOKyRejEXucaB24bmq1MHQEVQl2ySv3s23BUqZw==}
     dependencies:
       clsx: 2.1.0
     dev: false

--- a/userscript/src/@waze/Waze/DataModels/SegmentDataModel.ts
+++ b/userscript/src/@waze/Waze/DataModels/SegmentDataModel.ts
@@ -4,6 +4,7 @@ import {
 } from '@/@waze/Waze/DataModels/DataModel';
 import { RoadType } from '../enums';
 import { LineString } from '@turf/helpers';
+import { AddressDataModel } from './AddressDataModel';
 
 export interface SegmentDataModelAttributes extends DataModelAttributes {
   roadType: RoadType;
@@ -56,6 +57,7 @@ export interface SegmentDataModelAttributes extends DataModelAttributes {
 }
 export interface SegmentDataModel
   extends DataModel<SegmentDataModelAttributes> {
+  getAddress(): AddressDataModel;
   isLockedByHigherRank(): boolean;
   isWalkingRoadType(): boolean;
   isRoutable(): boolean;

--- a/userscript/src/@waze/Waze/classes/drive-renderer.d.ts
+++ b/userscript/src/@waze/Waze/classes/drive-renderer.d.ts
@@ -1,0 +1,29 @@
+import { LineString } from '@turf/helpers';
+
+export class DriveRenderer {
+  layer: any;
+  map: any;
+
+  constructor(layer: any, map: any);
+
+  /**
+   * Draws a path with a green color (like the one used for a "drive" selected from the navigation history). Can be used for drawing allowed paths.
+   * @param geometries The line strings to draw
+   */
+  drawUserDrives(geometries: LineString[]): void;
+
+  /**
+   * Draws a path with a red color to indicate a path is disallowed
+   * @param geometries The line strings to draw
+   */
+  drawDisallowedPaths(geometries: LineString[]): void;
+
+  /**
+   * Draws a path with a purple color (used internally for "Suggested routes" in Update Requests)
+   * @param geometries The line strings to draw
+   */
+  drawSuggestedRoute(geometries: LineString[]): void;
+
+  /** Clears the entire layer from any paths */
+  clear(): void;
+}

--- a/userscript/src/@waze/Waze/classes/drive-renderer.js
+++ b/userscript/src/@waze/Waze/classes/drive-renderer.js
@@ -3,6 +3,9 @@ import { getWazeMapEditorWindow } from '../../../utils/get-wme-window';
 function getDriveRendererConstructor() {
   const driveRendererInstance =
     getWazeMapEditorWindow().W.map.driveLayerController.driveRenderer;
+  if (!driveRendererInstance)
+    throw new Error('DriveRenderer instance not found');
+
   return Object.getPrototypeOf(driveRendererInstance).constructor;
 }
 export const DriveRenderer = getDriveRendererConstructor();

--- a/userscript/src/@waze/Waze/classes/drive-renderer.js
+++ b/userscript/src/@waze/Waze/classes/drive-renderer.js
@@ -1,0 +1,8 @@
+import { getWazeMapEditorWindow } from '../../../utils/get-wme-window';
+
+function getDriveRendererConstructor() {
+  const driveRendererInstance =
+    getWazeMapEditorWindow().W.map.driveLayerController.driveRenderer;
+  return Object.getPrototypeOf(driveRendererInstance).constructor;
+}
+export const DriveRenderer = getDriveRendererConstructor();

--- a/userscript/src/@waze/Waze/classes/index.ts
+++ b/userscript/src/@waze/Waze/classes/index.ts
@@ -1,0 +1,1 @@
+export { DriveRenderer } from './drive-renderer';

--- a/userscript/src/classes/index.ts
+++ b/userscript/src/classes/index.ts
@@ -1,0 +1,1 @@
+export { TurnsRenderer } from './turns-renderer';

--- a/userscript/src/classes/turns-renderer.ts
+++ b/userscript/src/classes/turns-renderer.ts
@@ -1,0 +1,98 @@
+import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
+import { Turn } from '@/@waze/Waze/Model/turn';
+import { Vertex } from '@/@waze/Waze/Vertex';
+import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+import { LineString, lineString } from '@turf/helpers';
+
+function cloneInstance(instance: any, overrideProps: any = {}) {
+  const prototype = Object.getPrototypeOf(instance);
+  return Object.assign(Object.create(prototype), instance, overrideProps);
+}
+
+const getPathTurnsLayerConstructor = (() => {
+  let constructor: any = null;
+  const getExistingInstance = () => {
+    const map = getWazeMapEditorWindow().W.map;
+    if (map.pathTurnsLayer) return map.pathTurnsLayer;
+    map._showPathLayer();
+    const layer = map.pathTurnsLayer;
+    map._hidePathLayer();
+    return layer;
+  };
+  const createNewConstructor = () => {
+    const pathTurnsLayerInstance = getExistingInstance();
+    return pathTurnsLayerInstance.constructor;
+  };
+
+  return () => {
+    if (constructor) return constructor;
+    return (constructor = createNewConstructor());
+  };
+})();
+function createPathTurnsLayer(
+  dataModel: any,
+  selectionManager: any,
+  map: any,
+  targetLayer: any,
+) {
+  const constructor = getPathTurnsLayerConstructor();
+  return new constructor(dataModel, selectionManager, map, targetLayer);
+}
+
+function shimDataModelTurnGraphEvents(dataModel: any) {
+  const shimTurnGraph = cloneInstance(dataModel.getTurnGraph(), {
+    on: () => {},
+    off: () => {},
+  });
+  return cloneInstance(dataModel, {
+    turnGraph: shimTurnGraph,
+    getTurnGraph: () => shimTurnGraph,
+  });
+}
+
+export class TurnsRenderer {
+  private _pathTurnsLayer: any;
+  private _dataModel: any;
+
+  constructor(dataModel: any, map: any, targetLayer: any) {
+    this._pathTurnsLayer = createPathTurnsLayer(
+      shimDataModelTurnGraphEvents(dataModel),
+      null,
+      map,
+      targetLayer,
+    );
+    this._dataModel = dataModel;
+  }
+
+  destroy() {
+    this._pathTurnsLayer.destroy();
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
+
+  private _getSegmentById(id: number): SegmentDataModel {
+    return this._dataModel.segments.getObjectById(id);
+  }
+  private _getVertexGeometry(vertex: Vertex): LineString {
+    const segment = this._getSegmentById(vertex.getSegmentID());
+    const geometryCoordinates = [
+      ...segment.getAttribute('geoJSONGeometry').coordinates,
+    ];
+    if (vertex.direction === 'rev') geometryCoordinates.toReversed();
+    return lineString(geometryCoordinates).geometry;
+  }
+  highlightTurn(turn: Turn) {
+    this._pathTurnsLayer.highlightPath(turn);
+    const fromGeometry = this._getVertexGeometry(turn.fromVertex);
+    const toGeometry = this._getVertexGeometry(turn.toVertex);
+    this._pathTurnsLayer._userDriveRenderer.drawUserDrives([
+      fromGeometry,
+      toGeometry,
+    ]);
+  }
+  clearHighlightedTurns() {
+    this._pathTurnsLayer.clearHighlightedPaths();
+  }
+}

--- a/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntry.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntry.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx';
+import { WzListItem } from '@wazespace/wme-react-components';
+import { TurnListViewEntryStreetNames } from './TurnListViewEntryStreetNames';
+
+interface TurnListViewEntryProps {
+  fromStreetName: string;
+  toStreetName: string;
+  showFromStreet: boolean;
+  isTurnAllowed: boolean;
+  onClick?(): void;
+  onMouseOver?(): void;
+  onMouseOut?(): void;
+}
+export function TurnListViewEntry({
+  fromStreetName,
+  toStreetName,
+  showFromStreet,
+  isTurnAllowed,
+  onClick,
+  onMouseOver,
+  onMouseOut,
+}: TurnListViewEntryProps) {
+  const itemKeyChildren = (
+    <div>
+      <div
+        className={clsx(
+          'arrow fa fa-arrow-right',
+          isTurnAllowed ? 'allowed' : 'disallowed',
+        )}
+      />
+      <TurnListViewEntryStreetNames
+        fromStreet={fromStreetName}
+        toSteet={toStreetName}
+        showFromStreet={showFromStreet}
+      />
+    </div>
+  );
+
+  return (
+    <WzListItem
+      className="exit-item"
+      itemKey={itemKeyChildren}
+      disabled={'false' as any} // required as the underlying WME stylesheet looks for a "false" string in this property
+      onClick={onClick}
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+    />
+  );
+}

--- a/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntry.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntry.tsx
@@ -30,7 +30,7 @@ export function TurnListViewEntry({
       />
       <TurnListViewEntryStreetNames
         fromStreet={fromStreetName}
-        toSteet={toStreetName}
+        toStreet={toStreetName}
         showFromStreet={showFromStreet}
       />
     </div>

--- a/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntryStreetNames.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntryStreetNames.tsx
@@ -1,0 +1,28 @@
+import { ReactElement } from 'react';
+
+function wrapStreetName(streetName: string): ReactElement {
+  return <span className="street-name">{streetName}</span>;
+}
+
+interface TurnListViewEntryStreeetNamesProps {
+  fromStreet: string;
+  toSteet: string;
+  showFromStreet: boolean;
+}
+export function TurnListViewEntryStreetNames({
+  fromStreet,
+  toSteet,
+  showFromStreet,
+}: TurnListViewEntryStreeetNamesProps): ReactElement {
+  const fromStreetChildren = wrapStreetName(fromStreet);
+  if (!showFromStreet) return fromStreetChildren;
+
+  const toStreetChildren = wrapStreetName(toSteet);
+  return (
+    <>
+      {fromStreetChildren}
+      {' to '}
+      {toStreetChildren}
+    </>
+  );
+}

--- a/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntryStreetNames.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/TurnListViewEntryStreetNames.tsx
@@ -6,18 +6,18 @@ function wrapStreetName(streetName: string): ReactElement {
 
 interface TurnListViewEntryStreeetNamesProps {
   fromStreet: string;
-  toSteet: string;
+  toStreet: string;
   showFromStreet: boolean;
 }
 export function TurnListViewEntryStreetNames({
   fromStreet,
-  toSteet,
+  toStreet,
   showFromStreet,
 }: TurnListViewEntryStreeetNamesProps): ReactElement {
   const fromStreetChildren = wrapStreetName(fromStreet);
   if (!showFromStreet) return fromStreetChildren;
 
-  const toStreetChildren = wrapStreetName(toSteet);
+  const toStreetChildren = wrapStreetName(toStreet);
   return (
     <>
       {fromStreetChildren}

--- a/userscript/src/components/edit-panel/big-junction-backup/components/TurnsListView.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/TurnsListView.tsx
@@ -1,0 +1,75 @@
+import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
+import { Turn } from '@/@waze/Waze/Model/turn';
+import { Vertex } from '@/@waze/Waze/Vertex';
+import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+import {
+  WzCaption,
+  WzCard,
+  WzLabel,
+  WzList,
+} from '@wazespace/wme-react-components';
+import { TurnListViewEntry } from './TurnListViewEntry';
+import { TurnsRenderer } from '@/classes';
+
+function getSegmentByVertex(segmentVertex: Vertex): SegmentDataModel {
+  const dataModel = getWazeMapEditorWindow().W.model;
+  const segmentId = segmentVertex.getSegmentID();
+  const segment: SegmentDataModel = dataModel.segments.getObjectById(segmentId);
+  if (!segment) throw new Error('Could not find segment in dataModel');
+  return segment;
+}
+
+function getStreetNameBySegment(segment: SegmentDataModel): string {
+  const address = segment.getAddress();
+  if (!address) return '';
+  return address.getStreetName();
+}
+
+function getStreetNameByVertex(segmentVertex: Vertex): string {
+  const segment = getSegmentByVertex(segmentVertex);
+  return getStreetNameBySegment(segment);
+}
+
+interface TurnsListViewProps {
+  title: string;
+  description?: string;
+  turns: Turn[];
+  showFromStreet?: boolean;
+  turnsHighlightRenderer: TurnsRenderer;
+}
+export function TurnsListView({
+  title,
+  description,
+  turns,
+  showFromStreet = false,
+  turnsHighlightRenderer,
+}: TurnsListViewProps) {
+  const onEntryMouseOver = (turn: Turn) => {
+    turnsHighlightRenderer.highlightTurn(turn);
+  };
+  const onEntryMouseOut = () => {
+    turnsHighlightRenderer.clearHighlightedTurns();
+  };
+
+  return (
+    <div className="far-turn-list-view">
+      <WzLabel>{title}</WzLabel>
+      {description && <WzCaption>{description}</WzCaption>}
+      <WzCard>
+        <WzList>
+          {turns.map((turn) => (
+            <TurnListViewEntry
+              key={turn.getID()}
+              isTurnAllowed={turn.getTurnData().isAllowed()}
+              fromStreetName={getStreetNameByVertex(turn.getFromVertex())}
+              toStreetName={getStreetNameByVertex(turn.getToVertex())}
+              showFromStreet={showFromStreet}
+              onMouseOver={() => onEntryMouseOver(turn)}
+              onMouseOut={() => onEntryMouseOut()}
+            />
+          ))}
+        </WzList>
+      </WzCard>
+    </div>
+  );
+}

--- a/userscript/src/components/edit-panel/big-junction-backup/components/UnverifiedTurnsListView.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/UnverifiedTurnsListView.tsx
@@ -1,0 +1,27 @@
+import { useRestoreContext } from '../contexts';
+import { TurnsListView } from './TurnsListView';
+import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+import { useMemo } from 'react';
+import { TurnsRenderer } from '@/classes';
+
+export function UnverifiedTurnsListView() {
+  const { unverifiedTurns } = useRestoreContext();
+  const map = getWazeMapEditorWindow().W.map;
+  const dataModel = getWazeMapEditorWindow().W.model;
+  const turnsHighlightLayer = map.farTurnPathHighlightLayer;
+  const turnsHighlightRenderer = useMemo(() => {
+    return new TurnsRenderer(dataModel, map, turnsHighlightLayer);
+  }, [dataModel, map, turnsHighlightLayer]);
+
+  if (!unverifiedTurns.length) return null;
+
+  return (
+    <TurnsListView
+      title="Unverified turns"
+      description="These turns couldn't be restored and must be manually validated"
+      turns={unverifiedTurns}
+      showFromStreet
+      turnsHighlightRenderer={turnsHighlightRenderer}
+    />
+  );
+}

--- a/userscript/src/components/edit-panel/big-junction-backup/constants/meta-symbols.ts
+++ b/userscript/src/components/edit-panel/big-junction-backup/constants/meta-symbols.ts
@@ -1,1 +1,2 @@
 export const WAS_RESTORED_METADATA_SYMBOL = Symbol('__was_restored__');
+export const UNVERIFIED_TURN_METADATA_SYMBOL = Symbol('__unverified_turn__');

--- a/userscript/src/components/edit-panel/big-junction-backup/contexts/RestoreContext.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/contexts/RestoreContext.tsx
@@ -7,12 +7,15 @@ import { useSelectedDataModelsContext } from '@/contexts/SelectedDataModelsConte
 import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
 import { RestoreBigJunctionBackupAction } from '../actions';
 import { getBigJunctionTurns } from '@/utils/wme-entities/big-junction-turns';
+import { Turn } from '@/@waze/Waze/Model/turn';
+import { UNVERIFIED_TURN_METADATA_SYMBOL } from '../constants/meta-symbols';
 
 interface RestoreContextPayload {
   readonly targetBigJunction: BigJunctionDataModel;
   readonly isSameJunction: boolean;
   readonly hasJunctionNewTurns: boolean;
   readonly isBackupRestored: boolean;
+  readonly unverifiedTurns: Turn[];
   restore(): void;
 }
 interface RestoreContextProps {
@@ -57,6 +60,14 @@ export function RestoreContextProvider(props: RestoreContextProps) {
         isSameJunction,
         isBackupRestored,
         hasJunctionNewTurns,
+        unverifiedTurns: getBigJunctionTurns(targetBigJunction).filter(
+          (turn) =>
+            turn.isFarTurn() &&
+            Reflect.getMetadata(
+              UNVERIFIED_TURN_METADATA_SYMBOL,
+              turn.getTurnData(),
+            ) === true,
+        ),
         restore: restoreCurrentBackup,
       }}
     >

--- a/userscript/src/components/edit-panel/big-junction-backup/portals/NewBigJunctionFormGroup.ts
+++ b/userscript/src/components/edit-panel/big-junction-backup/portals/NewBigJunctionFormGroup.ts
@@ -1,0 +1,11 @@
+import { createReactPortal } from '@/utils';
+
+export const NewBigJunctionFormGroupPortal = createReactPortal(() => {
+  const firstFormGroup = document.querySelector(
+    '#edit-panel .big-junction.sidebar-column .tab-content #big-junction-edit-general > .form-group',
+  );
+  const newFormGroup = document.createElement('div');
+  newFormGroup.className = 'form-group side-panel-section';
+  firstFormGroup.after(newFormGroup);
+  return newFormGroup;
+});

--- a/userscript/src/components/edit-panel/big-junction-backup/portals/index.ts
+++ b/userscript/src/components/edit-panel/big-junction-backup/portals/index.ts
@@ -1,2 +1,3 @@
 export { BigJunctionActionsPortal } from './BigJunctionActions';
 export { BigJunctionAlertsPortal } from './BigJunctionAlerts';
+export { NewBigJunctionFormGroupPortal } from './NewBigJunctionFormGroup';

--- a/userscript/src/components/edit-panel/big-junction-backup/template.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/template.tsx
@@ -7,11 +7,16 @@ import {
   useRestoreContext,
 } from './contexts';
 import { EnrollBackupButton, RestoreBackupButton } from './components';
-import { BigJunctionActionsPortal, BigJunctionAlertsPortal } from './portals';
+import {
+  BigJunctionActionsPortal,
+  BigJunctionAlertsPortal,
+  NewBigJunctionFormGroupPortal,
+} from './portals';
 import { BigJunctionBackup } from './models';
 import { backupNotRestoredSaveLock } from './backup-not-restored-save-lock';
 import { WzAlert } from '@wazespace/wme-react-components';
 import { useTranslate } from '@/hooks';
+import { UnverifiedTurnsListView } from './components/UnverifiedTurnsListView';
 
 export const BigJunctionBackupTemplate = class implements EditPanelTemplate {
   static backup: BigJunctionBackup = null;
@@ -57,6 +62,9 @@ export const BigJunctionBackupTemplate = class implements EditPanelTemplate {
               );
             })}
           </BigJunctionAlertsPortal>
+          <NewBigJunctionFormGroupPortal>
+            <UnverifiedTurnsListView />
+          </NewBigJunctionFormGroupPortal>
           <BigJunctionActionsPortal>
             <EnrollBackupButton />
             <RestoreBackupButton />

--- a/userscript/src/components/edit-panel/big-junction-backup/utils/index.ts
+++ b/userscript/src/components/edit-panel/big-junction-backup/utils/index.ts
@@ -3,5 +3,6 @@ export {
   isAllowedToEditBigJunctionTurnGuidance,
 } from './big-junction-permissions';
 export { compareJunctionToBackup } from './compare-junction-to-backup';
+export { omitUnexistingBigJunctionTurns } from './omit-unexisting-big-junction-turns';
 export { reconcileTurnSegments } from './turn-segments-reconciler';
 export { convertWMEAddressToBigJunctionAddress } from './wme-address-to-bj-address';

--- a/userscript/src/components/edit-panel/big-junction-backup/utils/omit-unexisting-big-junction-turns.ts
+++ b/userscript/src/components/edit-panel/big-junction-backup/utils/omit-unexisting-big-junction-turns.ts
@@ -1,0 +1,68 @@
+import { BigJunctionDataModel } from '@/@waze/Waze/DataModels/BigJunctionDataModel';
+import {
+  SegmentDataModel,
+  SegmentDataModelAttributes,
+} from '@/@waze/Waze/DataModels/SegmentDataModel';
+import { Turn } from '@/@waze/Waze/Model/turn';
+import {
+  getEntranceSegmentsByBigJunction,
+  getExitSegmentsByBigJunction,
+} from '@/utils/wme-entities/big-junction';
+import { isSegmentDirectionAllowed } from '@/utils/wme-entities/segment';
+
+type SegmentsMap = ReadonlyMap<
+  SegmentDataModelAttributes['id'],
+  SegmentDataModel
+>;
+
+function isTurnExistsInBigJunction(
+  turn: Turn,
+  entranceSegments: SegmentsMap,
+  exitSegments: SegmentsMap,
+) {
+  const fromSegment = entranceSegments.get(turn.fromVertex.getSegmentID());
+  if (
+    !fromSegment ||
+    !isSegmentDirectionAllowed(
+      fromSegment,
+      turn.fromVertex.direction === 'fwd' ? 'forward' : 'reverse',
+    )
+  ) {
+    return false;
+  }
+
+  const toSegment = exitSegments.get(turn.toVertex.getSegmentID());
+  if (
+    !toSegment ||
+    !isSegmentDirectionAllowed(
+      toSegment,
+      turn.toVertex.direction === 'fwd' ? 'forward' : 'reverse',
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function convertSegmentArrayToMap(segments: SegmentDataModel[]): SegmentsMap {
+  const map = new Map<SegmentDataModelAttributes['id'], SegmentDataModel>();
+  segments.forEach((segment) => map.set(segment.getAttribute('id'), segment));
+  return map;
+}
+
+export function omitUnexistingBigJunctionTurns(
+  bigJunction: BigJunctionDataModel,
+  turns: Turn[],
+): Turn[] {
+  const bigJunctionEntrances = convertSegmentArrayToMap(
+    getEntranceSegmentsByBigJunction(bigJunction),
+  );
+  const bigJunctionExits = convertSegmentArrayToMap(
+    getExitSegmentsByBigJunction(bigJunction),
+  );
+
+  return turns.filter((turn) =>
+    isTurnExistsInBigJunction(turn, bigJunctionEntrances, bigJunctionExits),
+  );
+}

--- a/userscript/src/utils/create-react-portal.ts
+++ b/userscript/src/utils/create-react-portal.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, ReactNode, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
@@ -6,9 +6,10 @@ interface PortalProps {
   portalKey?: string;
 }
 export function createReactPortal(
-  container: () => Element | DocumentFragment,
+  getContainer: () => Element | DocumentFragment,
 ): ComponentType<PortalProps> {
   return ({ children, portalKey }: PortalProps) => {
-    return createPortal(children, container(), portalKey);
+    const container = useMemo(() => getContainer(), []);
+    return createPortal(children, container, portalKey);
   };
 }


### PR DESCRIPTION
# Package Updates
As part of this pull request, the following packages have been updated:
| Package                         | Old version | New Version | Reason                      |
| ------------------------------- | ----------- | ----------- | ----------------------------|
| @wazespace/wme-react-components | 1.3.0-1     | 1.3.0-3     | Support for new components  |

# Implementation
To achieve the desired result, for every turn identified as unverified we define a metadata flag using `Reflect`, then, in the `RestoreContext` we pass all big junction turns that have this metadata flag. Then, using a newly created `TurnsRenderer` that uses Waze's implementation for paths we highlight the path on the map on hover.

# Additional changes
- To inject the list to a dynamically created target, the `createReactPortal` has been changed to memoize the container retrieved by the function. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `TurnsListView` and `UnverifiedTurnsListView` components for better turn management and validation.
  - Added `TurnListViewEntry` component to display and interact with individual turns.
  - Implemented `DriveRenderer` class for visualizing user drives, disallowed paths, and suggested routes.

- **Enhancements**
  - Added `getAddress()` method to `SegmentDataModel` for improved address handling.
  - Improved performance of `createReactPortal` by memoizing the container element.

- **Bug Fixes**
  - Enhanced filtering logic in `RestoreBigJunctionBackupAction` to handle unverified turns more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->