### PR TITLE
fix: compatibility issues with component changes

### DIFF
--- a/userscript/src/components/edit-panel/roundabout-exit-instruction-normalization/TooltipControl.tsx
+++ b/userscript/src/components/edit-panel/roundabout-exit-instruction-normalization/TooltipControl.tsx
@@ -1,3 +1,5 @@
+import { useVersionDependantConfig } from '@/hooks';
+import { WzLabel } from '@wazespace/wme-react-components';
 import { ReactNode } from 'react';
 
 interface TooltipControlProps {
@@ -5,9 +7,13 @@ interface TooltipControlProps {
   children: ReactNode;
 }
 export function TooltipControl({ label, children }: TooltipControlProps) {
+  const { LabelComponent } = useVersionDependantConfig([
+    { v: null, LabelComponent: 'label' },
+    { v: { M: 2, m: 229 }, LabelComponent: WzLabel },
+  ]);
   return (
     <div className="tooltip-control">
-      <label>{label}</label>
+      <LabelComponent>{label}</LabelComponent>
       {children}
     </div>
   );

--- a/userscript/src/hooks/index.ts
+++ b/userscript/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useTranslate';
 export * from './useSyncEffect';
 export * from './useInjectTranslations';
 export * from './useMutationObserver';
+export { useVersionDependantConfig } from './useVersionDependantConfig';

--- a/userscript/src/hooks/useVersionDependantConfig.ts
+++ b/userscript/src/hooks/useVersionDependantConfig.ts
@@ -1,0 +1,106 @@
+import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+
+interface Version {
+  M: number;
+  m: number;
+  p: number;
+}
+type VersionDependantConfigurationObject<T> = {
+  v: null | Partial<Version>;
+} & T;
+
+function useCurrentMapEditorVersion(): Version {
+  const rawVersion = getWazeMapEditorWindow().W.version;
+  const patchIndex = rawVersion.indexOf('-');
+  const patchIndexEnd = rawVersion.indexOf('-', patchIndex + 1);
+  const trimmedVersionString = rawVersion.substring(1, patchIndex);
+  const patchString = rawVersion.substring(patchIndex + 1, patchIndexEnd);
+  const versionParts = trimmedVersionString.split('.');
+  return {
+    M: parseInt(versionParts[0]),
+    m: parseInt(versionParts[1]),
+    p: parseInt(patchString),
+  };
+}
+
+export function useVersionDependantConfig<T>(
+  configurations: VersionDependantConfigurationObject<T>[],
+): T {
+  const currentVersion = useCurrentMapEditorVersion();
+  const compareVersions = (
+    majorA: number,
+    majorB: number,
+    minorA: number | undefined,
+    minorB: number | undefined,
+    patchA: number | undefined,
+    patchB: number | undefined,
+  ): number => {
+    if (majorA > majorB) return 1;
+    if (majorA < majorB) return -1;
+
+    if (minorA !== undefined && minorB !== undefined) {
+      if (minorA > minorB) return 1;
+      if (minorA < minorB) return -1;
+    }
+
+    if (patchA !== undefined && patchB !== undefined) {
+      if (patchA > patchB) return 1;
+      if (patchB < patchA) return -1;
+    }
+
+    return 0;
+  };
+  const isVersionAtLeast = (
+    major: number,
+    minor?: number,
+    patch?: number,
+  ): boolean => {
+    return (
+      compareVersions(
+        currentVersion.M,
+        major,
+        currentVersion.m,
+        minor,
+        currentVersion.p,
+        patch,
+      ) >= 0
+    );
+  };
+
+  let greatestOption: VersionDependantConfigurationObject<T> = null;
+  for (const option of configurations) {
+    const { v } = option;
+    if (!v) {
+      // if there is no version specified, we want to use this option if it is the first one we find
+      if (greatestOption == null) {
+        greatestOption = option;
+      }
+
+      continue;
+    }
+
+    // we have to validate the version specified in the option is suitable for the current version
+    if (isVersionAtLeast(v.M, v.m, v.p)) {
+      // we want to validate this option has a higher version than the previous greatest option
+      if (
+        !greatestOption?.v ||
+        compareVersions(
+          v.M,
+          greatestOption.v.M,
+          v.m,
+          greatestOption.v.m,
+          v.p,
+          greatestOption.v.p,
+        ) > 0
+      ) {
+        greatestOption = option;
+      }
+    }
+  }
+
+  if (!greatestOption)
+    throw new Error('No suitable configuration found for current version');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { v, ...rest } = greatestOption;
+  return rest as T;
+}


### PR DESCRIPTION
The Waze Map Editor team always strives to improve consistency between elements, and this causes to switch from default HTML tags to custom elements, which sometimes might break styling because of the change of the CSS as well (the selector is changed from the base HTML element to the custom element). Because multiple environments are running at the same time, and each has a different version - sometimes we might encounter that a single configuration isn't suitable for all environments. This is why this pull request includes a new hook: `useVersionDependantConfig` - this hook is responsible for accepting multiple configurations and the WME versions they are supported on, and the hook will pick the best candidate and return it, so other components can use with ease the right configuration for the WME environment they are currently running on. One example of this hook usage is the switch from the `label` tag to the `wz-label` tag on the turn tooltip for tooltip controls. We add a custom control to that turn tooltip when we have the ability to apply instructions to roundabouts, and this change by the WME team has caused our control to have broken styles in some environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic label selection in the TooltipControl component based on map editor version.
  - Added a new hook, `useVersionDependantConfig`, to manage version-dependent configurations.

- **Enhancements**
  - Improved the TooltipControl component to use the appropriate label component dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->