### PR TITLE
feat(JBU-54): enable roundaboutization of existing junction boxes

### DIFF
--- a/userscript/src/@waze/Waze/actions/delete-big-junction.action.d.ts
+++ b/userscript/src/@waze/Waze/actions/delete-big-junction.action.d.ts
@@ -4,6 +4,8 @@ import { Action } from './action';
 export class DeleteBigJunctionAction extends Action {
   actionName: 'DELETE_BIG_JUNCTION';
   bigJunction: BigJunctionDataModel;
+
+  constructor(bigJunction: BigJunctionDataModel);
 }
 
 export function isDeleteBigJunctionAction(

--- a/userscript/src/actions/update-big-junction-geom-to-roundabout.action.ts
+++ b/userscript/src/actions/update-big-junction-geom-to-roundabout.action.ts
@@ -14,13 +14,13 @@ export class UpdateBigJunctionGeometryToRoundaboutAction extends Action {
   shouldSerialize = false;
 
   private readonly _initialGeometry: Polygon;
-  private readonly _geometry: Polygon;
+  private _geometry: Polygon;
 
   constructor(
     public addBigJunctionAction: AddBigJunctionAction,
     public dataModel: any,
     public map: any,
-    sizeFactor = UpdateBigJunctionGeometryToRoundaboutAction.DefaultSizeFactor,
+    private _sizeFactor = UpdateBigJunctionGeometryToRoundaboutAction.DefaultSizeFactor,
     props?: unknown,
   ) {
     super(props);
@@ -29,10 +29,6 @@ export class UpdateBigJunctionGeometryToRoundaboutAction extends Action {
       getWazeMapEditorWindow().W.userscripts.toGeoJSONGeometry(
         addBigJunctionAction.initialGeometry,
       );
-    this._geometry = transformScale(
-      this._getRoundaboutPerimeterGeometry(),
-      sizeFactor,
-    );
   }
 
   private _getBigJunction(): BigJunctionDataModel {
@@ -97,6 +93,10 @@ export class UpdateBigJunctionGeometryToRoundaboutAction extends Action {
   }
 
   doAction(): boolean {
+    this._geometry = transformScale(
+      this._getRoundaboutPerimeterGeometry(),
+      this._sizeFactor,
+    );
     this._updateBigJunctionGeometry(this._geometry);
     return true;
   }
@@ -106,7 +106,7 @@ export class UpdateBigJunctionGeometryToRoundaboutAction extends Action {
   }
 
   redoAction() {
-    this.doAction();
+    this._updateBigJunctionGeometry(this._geometry);
   }
 
   generateDescription() {

--- a/userscript/src/components/edit-panel/roundabout-perimeter-geometry/CloneRoundaboutGeometryToBigJunctionButton.tsx
+++ b/userscript/src/components/edit-panel/roundabout-perimeter-geometry/CloneRoundaboutGeometryToBigJunctionButton.tsx
@@ -1,9 +1,14 @@
+import { AddBigJunctionAction, MultiAction } from '@/@waze/Waze/actions';
 import { BigJunctionDataModel } from '@/@waze/Waze/DataModels/BigJunctionDataModel';
 import { UpdateBigJunctionGeometryToRoundaboutAction } from '@/actions';
+import { BigJunctionBackup } from '@/components/edit-panel/big-junction-backup';
+import { RestoreBigJunctionBackupAction } from '@/components/edit-panel/big-junction-backup/actions';
 import { gtag } from '@/google-analytics';
 import { useTranslate } from '@/hooks';
 import { useFindBigJunctionAddAction } from '@/hooks/useFindBigJunctionAddAction';
 import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+import { createAddBigJunctionAction } from '@/utils/wme-feature-creation';
+import { createDeleteBigJunctionAction } from '@/utils/wme-feature-destroyer';
 import { WzButton } from '@wazespace/wme-react-components';
 
 interface CloneRoundaboutGeometryToBigJunctionButtonProps {
@@ -15,24 +20,55 @@ export function CloneRoundaboutGeometryToBigJunctionButton({
   const t = useTranslate();
   const addBigJunctionAction = useFindBigJunctionAddAction(bigJunction);
 
-  const handleButtonClick = () => {
+  const getUpdateBigJunctionGeometryAction = (
+    addBigJunctionAction: AddBigJunctionAction,
+  ) => {
     const dataModel = getWazeMapEditorWindow().W.model;
     const map = getWazeMapEditorWindow().W.map;
-    const action = new UpdateBigJunctionGeometryToRoundaboutAction(
+    return new UpdateBigJunctionGeometryToRoundaboutAction(
       addBigJunctionAction,
       dataModel,
       map,
     );
-    dataModel.actionManager.add(action);
+  };
+
+  const recreateBigJunction = () => {
+    const backup = BigJunctionBackup.fromBigJunction(bigJunction);
+    const newBigJunctionAction = createAddBigJunctionAction(
+      bigJunction.getAttribute('geoJSONGeometry'),
+    );
+    newBigJunctionAction.__jbuSkipAutoRoundaboutize = true;
+    const updateBigJunctionGeomAction =
+      getUpdateBigJunctionGeometryAction(newBigJunctionAction);
+    const multiAction = new MultiAction([
+      createDeleteBigJunctionAction(bigJunction),
+      newBigJunctionAction,
+      updateBigJunctionGeomAction,
+      new RestoreBigJunctionBackupAction(
+        newBigJunctionAction.bigJunction,
+        backup,
+        [],
+      ),
+    ]);
+    multiAction.generateDescription = () => {
+      updateBigJunctionGeomAction.generateDescription();
+      (multiAction as any)._description = (
+        updateBigJunctionGeomAction as any
+      )._description;
+    };
+    return multiAction;
+  };
+
+  const handleButtonClick = () => {
+    const actionToApply = addBigJunctionAction
+      ? getUpdateBigJunctionGeometryAction(addBigJunctionAction)
+      : recreateBigJunction();
+    getWazeMapEditorWindow().W.model.actionManager.add(actionToApply);
     gtag('event', 'roundaboutize_big_junction');
   };
 
   return (
-    <WzButton
-      color="text"
-      disabled={!addBigJunctionAction}
-      onClick={handleButtonClick}
-    >
+    <WzButton color="text" onClick={handleButtonClick}>
       {t('jb_utils.big_junction.actions.clone_roundabout_geom')}
     </WzButton>
   );

--- a/userscript/src/components/edit-panel/roundabout-perimeter-geometry/template.tsx
+++ b/userscript/src/components/edit-panel/roundabout-perimeter-geometry/template.tsx
@@ -19,7 +19,6 @@ export const RoundaboutPerimeterPolygonTemplate: EditPanelTemplateConstructor<Bi
   static isEnabledForElements(bigJunctions: BigJunctionDataModel[]): boolean {
     return (
       bigJunctions.length === 1 &&
-      bigJunctions[0].state === 'INSERT' &&
       bigJunctions[0]
         .getShortSegments()
         .every((segment) => segment.isInRoundabout())

--- a/userscript/src/utils/wme-feature-destroyer/big-junction/create-delete-big-junction-action.ts
+++ b/userscript/src/utils/wme-feature-destroyer/big-junction/create-delete-big-junction-action.ts
@@ -1,0 +1,10 @@
+import { DeleteBigJunctionAction } from '@/@waze/Waze/actions';
+import { BigJunctionDataModel } from '@/@waze/Waze/DataModels/BigJunctionDataModel';
+import { getDeleteBigJunctionActionProto } from '@/utils/wme-feature-destroyer/big-junction/get-delete-big-junction-action-proto';
+
+export function createDeleteBigJunctionAction(
+  bigJunction: BigJunctionDataModel,
+): DeleteBigJunctionAction {
+  const deleteBigJunctionProto = getDeleteBigJunctionActionProto();
+  return new deleteBigJunctionProto(bigJunction);
+}

--- a/userscript/src/utils/wme-feature-destroyer/big-junction/get-delete-big-junction-action-proto.ts
+++ b/userscript/src/utils/wme-feature-destroyer/big-junction/get-delete-big-junction-action-proto.ts
@@ -1,0 +1,33 @@
+import {
+  DeleteBigJunctionAction,
+  isDeleteBigJunctionAction,
+} from '@/@waze/Waze/actions';
+import { getActionsCreatedInContext } from '@/utils/wme-action-manager';
+import { createAddBigJunctionAction } from '@/utils/wme-feature-creation';
+import { getDeleteFeatureFunction } from '@/utils/wme-feature-destroyer';
+import { polygon } from '@turf/helpers';
+
+let deleteBigJunctionAction: typeof DeleteBigJunctionAction = null;
+
+export function getDeleteBigJunctionActionProto(): typeof DeleteBigJunctionAction {
+  if (deleteBigJunctionAction) return deleteBigJunctionAction;
+
+  const addedActions = getActionsCreatedInContext(() => {
+    const addBigJunctionAction = createAddBigJunctionAction(
+      polygon([
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ]).geometry,
+    );
+    const deleteFeatures = getDeleteFeatureFunction();
+    deleteFeatures([addBigJunctionAction.bigJunction]);
+  });
+  deleteBigJunctionAction = Object.getPrototypeOf(
+    addedActions.find((action) => isDeleteBigJunctionAction(action)),
+  ).constructor;
+  return deleteBigJunctionAction;
+}

--- a/userscript/src/utils/wme-feature-destroyer/big-junction/index.ts
+++ b/userscript/src/utils/wme-feature-destroyer/big-junction/index.ts
@@ -1,0 +1,1 @@
+export { createDeleteBigJunctionAction } from './create-delete-big-junction-action';

--- a/userscript/src/utils/wme-feature-destroyer/get-delete-feature-func.ts
+++ b/userscript/src/utils/wme-feature-destroyer/get-delete-feature-func.ts
@@ -1,0 +1,27 @@
+import { DataModel } from '@/@waze/Waze/DataModels/DataModel';
+import { findFiberParentNode, getReactFiberNode } from '@/utils/react-fiber';
+
+type DeleteFeatures = (features: DataModel[]) => void;
+let deleteFeaturesFunction: DeleteFeatures = null;
+
+function getDeleteFeaturesBtn(): HTMLElement {
+  return document.getElementById('delete-button');
+}
+
+export function getDeleteFeatureFunction(): DeleteFeatures {
+  const deleteFeaturesBtn = getDeleteFeaturesBtn();
+  const btnElementFiber = getReactFiberNode(deleteFeaturesBtn);
+  const btnComponentInstance = findFiberParentNode(
+    btnElementFiber,
+    (fiber) =>
+      fiber.stateNode && typeof fiber.stateNode.deleteFeatures === 'function',
+  );
+  const deleteFeaturesRaw = btnComponentInstance.stateNode.deleteFeatures;
+  deleteFeaturesFunction = (features) => {
+    const origFeatures = btnComponentInstance.stateNode.features;
+    btnComponentInstance.stateNode.features = features;
+    deleteFeaturesRaw.call(btnComponentInstance.stateNode);
+    btnComponentInstance.stateNode.features = origFeatures;
+  };
+  return deleteFeaturesFunction;
+}

--- a/userscript/src/utils/wme-feature-destroyer/index.ts
+++ b/userscript/src/utils/wme-feature-destroyer/index.ts
@@ -1,0 +1,2 @@
+export * from './big-junction';
+export { getDeleteFeatureFunction } from './get-delete-feature-func';


### PR DESCRIPTION
As part of this pull request, I implemented utility functions to delete features, creating "delete big junction" actions, refactored the restore snapshot action a bit to reconcile the turns upon the action being invoked (instead of immediately in the constructor), which helps when the junction box is not yet created when the constructor is being called.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to delete and restore big junctions.
  - Introduced new actions for handling roundabout geometry updates.
  - Enhanced the edit panel with backup and restore actions for big junctions.

- **Improvements**
  - Improved the handling of big junction geometry transformations.
  - Streamlined the process for updating and recreating big junctions.

- **Bug Fixes**
  - Fixed an issue with the `isEnabledForElements` method in the roundabout perimeter polygon template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->