### PR TITLE
feat(JBU-55): enable automatic setting of turn arrows in roundabout lane guidance

### DIFF
--- a/userscript/jest.config.json
+++ b/userscript/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "testEnvironment": "jsdom"
+}

--- a/userscript/package.json
+++ b/userscript/package.json
@@ -20,6 +20,7 @@
     "@babel/preset-env": "^7.24.5",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
+    "@types/backbone": "^1.4.19",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.0",
     "@types/react": "^17.0.76",

--- a/userscript/package.json
+++ b/userscript/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.2.5",
     "terser-webpack-plugin": "^5.3.10",
     "ts-loader": "^9.5.1",

--- a/userscript/pnpm-lock.yaml
+++ b/userscript/pnpm-lock.yaml
@@ -118,6 +118,9 @@ devDependencies:
   jest:
     specifier: ^29.7.0
     version: 29.7.0
+  jest-environment-jsdom:
+    specifier: ^29.7.0
+    version: 29.7.0
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
@@ -2083,6 +2086,11 @@ packages:
       tippy.js: 6.3.7
     dev: false
 
+  /@tootallnate/once@2.0.0:
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /@turf/bbox@6.5.0:
     resolution: {integrity: sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==}
     dependencies:
@@ -2269,6 +2277,14 @@ packages:
       '@types/sizzle': 2.3.8
     dev: true
 
+  /@types/jsdom@20.0.1:
+    resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
+    dependencies:
+      '@types/node': 20.11.25
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.1.2
+    dev: true
+
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
@@ -2322,6 +2338,10 @@ packages:
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+    dev: true
+
+  /@types/tough-cookie@4.0.5:
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
     dev: true
 
   /@types/underscore@1.11.15:
@@ -2635,6 +2655,18 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: true
 
+  /abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
+    dev: true
+
+  /acorn-globals@7.0.1:
+    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+    dependencies:
+      acorn: 8.11.3
+      acorn-walk: 8.3.3
+    dev: true
+
   /acorn-import-assertions@1.9.0(acorn@8.11.3):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
@@ -2651,10 +2683,26 @@ packages:
       acorn: 8.11.3
     dev: true
 
+  /acorn-walk@8.3.3:
+    resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.11.3
+    dev: true
+
   /acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
+
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /ajv-formats@2.1.1(ajv@8.12.0):
@@ -2852,7 +2900,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -3182,7 +3229,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: false
 
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -3263,8 +3309,32 @@ packages:
       which: 2.0.2
     dev: true
 
+  /cssom@0.3.8:
+    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
+    dev: true
+
+  /cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+    dev: true
+
+  /cssstyle@2.3.0:
+    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cssom: 0.3.8
+    dev: true
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  /data-urls@3.0.2:
+    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+    dev: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -3276,6 +3346,10 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
+
+  /decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
     dev: true
 
   /dedent@1.5.3:
@@ -3316,7 +3390,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -3349,6 +3422,14 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
+    dependencies:
+      webidl-conversions: 7.0.0
+    dev: true
+
   /electron-to-chromium@1.4.699:
     resolution: {integrity: sha512-I7q3BbQi6e4tJJN5CRcyvxhK0iJb34TV8eJQcgh+fR2fQ8miMgZcEInckCo1U9exDHbfz7DLDnFn8oqH/VcRKw==}
     dev: true
@@ -3368,6 +3449,11 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+    dev: true
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
     dev: true
 
   /envinfo@7.11.1:
@@ -3506,6 +3592,18 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  /escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+    dev: true
 
   /eslint-config-prettier@9.1.0(eslint@8.57.0):
     resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
@@ -3856,7 +3954,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: false
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -4049,13 +4146,48 @@ packages:
       react-is: 16.13.1
     dev: false
 
+  /html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+    dependencies:
+      whatwg-encoding: 2.0.0
+    dev: true
+
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
+  /http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
 
   /ignore@5.3.1:
@@ -4225,6 +4357,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
+    dev: true
+
+  /is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: true
 
   /is-regex@1.1.4:
@@ -4506,6 +4642,29 @@ packages:
       jest-get-type: 29.6.3
       jest-util: 29.7.0
       pretty-format: 29.7.0
+    dev: true
+
+  /jest-environment-jsdom@29.7.0:
+    resolution: {integrity: sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/jsdom': 20.0.1
+      '@types/node': 20.11.25
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+      jsdom: 20.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /jest-environment-node@29.7.0:
@@ -4811,6 +4970,47 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /jsdom@20.0.3:
+    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.11.3
+      acorn-globals: 7.0.1
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.4.3
+      domexception: 4.0.0
+      escodegen: 2.1.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.10
+      parse5: 7.1.2
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+      ws: 8.17.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
@@ -5062,6 +5262,10 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /nwsapi@2.2.10:
+    resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
+    dev: true
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5207,6 +5411,12 @@ packages:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5318,6 +5528,10 @@ packages:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: false
 
+  /psl@1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5325,6 +5539,10 @@ packages:
 
   /pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+    dev: true
+
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
 
   /queue-microtask@1.2.3:
@@ -5481,6 +5699,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: true
+
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -5562,6 +5784,17 @@ packages:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-regex: 1.1.4
+    dev: true
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
+
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
     dev: true
 
   /scheduler@0.23.0:
@@ -5834,6 +6067,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  /symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
   /synckit@0.8.8:
     resolution: {integrity: sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5931,8 +6168,25 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: true
+
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
+
+  /tr46@3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      punycode: 2.3.1
     dev: true
 
   /ts-api-utils@1.3.0(typescript@5.4.2):
@@ -6076,6 +6330,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -6091,6 +6350,13 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+    dev: true
+
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
     dev: true
 
   /usehooks-ts@2.16.0(react@18.2.0):
@@ -6117,6 +6383,13 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
+  /w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+    dependencies:
+      xml-name-validator: 4.0.0
+    dev: true
+
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
@@ -6133,6 +6406,11 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
     dev: true
 
   /webpack-cli@5.1.4(webpack@5.90.3):
@@ -6242,6 +6520,26 @@ packages:
       - uglify-js
     dev: true
 
+  /whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-url@11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
@@ -6329,6 +6627,28 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+    dev: true
+
+  /ws@8.17.0:
+    resolution: {integrity: sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
 
   /y18n@5.0.8:

--- a/userscript/pnpm-lock.yaml
+++ b/userscript/pnpm-lock.yaml
@@ -73,6 +73,9 @@ devDependencies:
   '@babel/preset-typescript':
     specifier: ^7.23.3
     version: 7.23.3(@babel/core@7.24.0)
+  '@types/backbone':
+    specifier: ^1.4.19
+    version: 1.4.19
   '@types/jest':
     specifier: ^29.5.12
     version: 29.5.12
@@ -2206,6 +2209,13 @@ packages:
       '@babel/types': 7.24.0
     dev: true
 
+  /@types/backbone@1.4.19:
+    resolution: {integrity: sha512-byyn236JymGByOajKA7mi1k+/jKn162TIvArOB4SHgOGbVlFj8CSfJH4jekP0qo0vJwW5khrrsiiO1Jsos6ZvA==}
+    dependencies:
+      '@types/jquery': 3.5.30
+      '@types/underscore': 1.11.15
+    dev: true
+
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
@@ -2251,6 +2261,12 @@ packages:
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0
+    dev: true
+
+  /@types/jquery@3.5.30:
+    resolution: {integrity: sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==}
+    dependencies:
+      '@types/sizzle': 2.3.8
     dev: true
 
   /@types/json-schema@7.0.15:
@@ -2300,8 +2316,16 @@ packages:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
 
+  /@types/sizzle@2.3.8:
+    resolution: {integrity: sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==}
+    dev: true
+
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+    dev: true
+
+  /@types/underscore@1.11.15:
+    resolution: {integrity: sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==}
     dev: true
 
   /@types/validator@13.11.9:

--- a/userscript/src/@waze/Waze/DataModels/SegmentDataModel.ts
+++ b/userscript/src/@waze/Waze/DataModels/SegmentDataModel.ts
@@ -67,4 +67,6 @@ export interface SegmentDataModel
   hasToBigJunction(): boolean;
   getRoundabout(): boolean;
   isInRoundabout(): boolean;
+  getFwdHeading(): number;
+  getRevHeading(): number;
 }

--- a/userscript/src/@waze/Waze/enums/index.ts
+++ b/userscript/src/@waze/Waze/enums/index.ts
@@ -1,2 +1,3 @@
+export * from './lane-guidance.enum';
 export * from './permanent-hazard-type.enum';
 export * from './road-type.enum';

--- a/userscript/src/@waze/Waze/enums/lane-guidance.enum.ts
+++ b/userscript/src/@waze/Waze/enums/lane-guidance.enum.ts
@@ -1,0 +1,11 @@
+export enum LaneGuidanceMode {
+  Default = 0,
+  Display = 1,
+  DisplayAndVoice = 2,
+}
+
+export enum LaneGuidanceInstructionStrategy {
+  Default = 0,
+  Pull = 1,
+  Push = 2,
+}

--- a/userscript/src/App.tsx
+++ b/userscript/src/App.tsx
@@ -10,6 +10,7 @@ import { useInjectTranslations, usePreference } from './hooks';
 import FallbackUserscriptTranslations from './resources/localization/userscript.json';
 import { LanguageTranslations } from './@waze/I18n';
 import { BigJunctionBackupTemplate } from './components/edit-panel/big-junction-backup';
+import { LaneGuidanceAutoTurnArrow } from './components/edit-panel/lg-auto-turn-arrow/template';
 
 interface AppProps {
   translations: LanguageTranslations;
@@ -29,6 +30,7 @@ export function App(props: AppProps) {
               RoundaboutPerimeterPolygonTemplate,
               BigJunctionBackupTemplate,
               InstructionsApplicationTemplate,
+              LaneGuidanceAutoTurnArrow,
             ]}
           />
           <BackgroundActions />

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/SetTurnArrowsButton.tsx
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/SetTurnArrowsButton.tsx
@@ -1,0 +1,36 @@
+import { useTranslate } from '@/hooks';
+import { WzButton } from '@wazespace/wme-react-components';
+import { createPortal } from 'react-dom';
+import { useLaneGuidanceControl, useFarTurnsControlLabel } from '../hooks';
+import { setControlTurnArrows } from '../utils';
+import { SyntheticEvent } from 'react';
+
+interface SetTurnArrowsButtonProps {
+  lanesDirection: 'fwd' | 'rev';
+}
+export function SetTurnArrowsButton({
+  lanesDirection,
+}: SetTurnArrowsButtonProps) {
+  const laneGuidanceControl = useLaneGuidanceControl(lanesDirection);
+  const controlLabel = useFarTurnsControlLabel(lanesDirection);
+  const t = useTranslate('jb_utils.lanes');
+
+  const setTurnArrows = (e: SyntheticEvent) => {
+    setControlTurnArrows(laneGuidanceControl);
+    if (e.currentTarget instanceof HTMLElement) e.currentTarget.blur();
+  };
+
+  if (!controlLabel) return null;
+  return createPortal(
+    <WzButton
+      style={{ verticalAlign: 'middle', marginLeft: 8 }}
+      onClick={setTurnArrows}
+      size="sm"
+      color="secondary"
+    >
+      <i className="w-icon w-icon-themes" />
+      {t('set_turn_arrows')}
+    </WzButton>,
+    controlLabel,
+  );
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/SetTurnArrowsButton.tsx
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/SetTurnArrowsButton.tsx
@@ -15,7 +15,7 @@ export function SetTurnArrowsButton({
   onTurnArrowsSetAutomatically,
 }: SetTurnArrowsButtonProps) {
   const [autoSetTurnArrows] = usePreference(
-    'auto_set_roundabuot_lane_guidance_turn_arrows',
+    'auto_set_roundabout_lane_guidance_turn_arrows',
   );
   const laneGuidanceControl = useLaneGuidanceControl(lanesDirection);
   const controlLabel = useFarTurnsControlLabel(lanesDirection);

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/SetTurnArrowsButton.tsx
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/SetTurnArrowsButton.tsx
@@ -1,19 +1,41 @@
-import { useTranslate } from '@/hooks';
+import { usePreference, useTranslate } from '@/hooks';
 import { WzButton } from '@wazespace/wme-react-components';
 import { createPortal } from 'react-dom';
 import { useLaneGuidanceControl, useFarTurnsControlLabel } from '../hooks';
 import { setControlTurnArrows } from '../utils';
-import { SyntheticEvent } from 'react';
+import { SyntheticEvent, useEffect, useRef } from 'react';
+import { SetTurnArrowsEvent } from '../events';
 
 interface SetTurnArrowsButtonProps {
   lanesDirection: 'fwd' | 'rev';
+  onTurnArrowsSetAutomatically?(event: SetTurnArrowsEvent): void;
 }
 export function SetTurnArrowsButton({
   lanesDirection,
+  onTurnArrowsSetAutomatically,
 }: SetTurnArrowsButtonProps) {
+  const [autoSetTurnArrows] = usePreference(
+    'auto_set_roundabuot_lane_guidance_turn_arrows',
+  );
   const laneGuidanceControl = useLaneGuidanceControl(lanesDirection);
   const controlLabel = useFarTurnsControlLabel(lanesDirection);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const t = useTranslate('jb_utils.lanes');
+
+  useEffect(() => {
+    if (autoSetTurnArrows && controlLabel && buttonRef.current) {
+      const event = new SetTurnArrowsEvent({
+        associatedButton: buttonRef.current,
+      });
+      onTurnArrowsSetAutomatically?.(event);
+      if (!event.defaultPrevented) setControlTurnArrows(laneGuidanceControl);
+    }
+  }, [
+    autoSetTurnArrows,
+    controlLabel,
+    laneGuidanceControl,
+    onTurnArrowsSetAutomatically,
+  ]);
 
   const setTurnArrows = (e: SyntheticEvent) => {
     setControlTurnArrows(laneGuidanceControl);
@@ -27,6 +49,7 @@ export function SetTurnArrowsButton({
       onClick={setTurnArrows}
       size="sm"
       color="secondary"
+      ref={buttonRef}
     >
       <i className="w-icon w-icon-themes" />
       {t('set_turn_arrows')}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/index.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/components/index.ts
@@ -1,0 +1,1 @@
+export { SetTurnArrowsButton } from './SetTurnArrowsButton';

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/events/index.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/events/index.ts
@@ -1,0 +1,1 @@
+export { SetTurnArrowsEvent } from './set-turn-arrows.event';

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/events/set-turn-arrows.event.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/events/set-turn-arrows.event.ts
@@ -1,0 +1,21 @@
+interface SetTurnArrowsEventDetails {
+  associatedButton: HTMLButtonElement;
+}
+export class SetTurnArrowsEvent extends CustomEvent<SetTurnArrowsEventDetails> {
+  constructor(detail: SetTurnArrowsEventDetails) {
+    super('setturnarrows', {
+      bubbles: false,
+      cancelable: false,
+      detail,
+    });
+
+    Object.defineProperties(this, {
+      target: {
+        value: detail.associatedButton,
+      },
+      currentTarget: {
+        value: detail.associatedButton,
+      },
+    });
+  }
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/hooks/index.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useFarTurnsControlLabel } from './use-far-turns-control-label';
+export {
+  useLaneGuidanceControl,
+  useLaneGuidanceControlElement,
+} from './use-lane-guidance-control';

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/hooks/use-far-turns-control-label.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/hooks/use-far-turns-control-label.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useMutationObserver } from '@/hooks';
+import { useLaneGuidanceControlElement } from './use-lane-guidance-control';
+import { isElementNode } from '@/utils/dom-node';
+
+export function useFarTurnsControlLabel(direction: 'fwd' | 'rev'): Element {
+  const [lanesControlLabel, setLanesControlLabel] = useState<Element>(null);
+  const laneGuidanceControlElement = useLaneGuidanceControlElement(direction);
+  useMutationObserver(
+    laneGuidanceControlElement,
+    ([mutation]) => {
+      if (!isElementNode(mutation.target)) return;
+      const label = Array.prototype.at.call(
+        mutation.target.querySelectorAll('.form-group.turns > label'),
+        -1,
+      );
+      setLanesControlLabel(label);
+    },
+    { childList: true },
+  );
+
+  return lanesControlLabel;
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/hooks/use-lane-guidance-control.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/hooks/use-lane-guidance-control.ts
@@ -1,0 +1,54 @@
+import { useMutationObserver } from '@/hooks';
+import {
+  findLaneGuidanceContainerByDirection,
+  findLaneGuidanceControlModelByLanesControl,
+  findLaneGuidanceEditRegionContainer,
+  isLanesControlElement,
+} from '../utils';
+import { useMemo, useState } from 'react';
+import { isElementNode } from '@/utils/dom-node';
+
+function findLanesControlNodeInList(nodeList: NodeList): Element {
+  return Array.prototype.find.call(
+    nodeList,
+    (node: Node) => isElementNode(node) && isLanesControlElement(node),
+  );
+}
+
+export function useLaneGuidanceControlElement(
+  lanesDirection: 'fwd' | 'rev',
+): Element {
+  const laneGuidanceContainer =
+    findLaneGuidanceContainerByDirection(lanesDirection);
+  const editRegionContainer = findLaneGuidanceEditRegionContainer(
+    laneGuidanceContainer,
+  );
+
+  const [lanesControlElement, setLanesControlElement] = useState<Element>(null);
+
+  useMutationObserver(
+    editRegionContainer,
+    ([mutation]) => {
+      const addedNode = findLanesControlNodeInList(mutation.addedNodes);
+      const removedNode = findLanesControlNodeInList(mutation.removedNodes);
+
+      const isAdded = addedNode && !removedNode;
+      const isRemoved = !addedNode && removedNode;
+      const isChanged = isAdded || isRemoved;
+      if (!isChanged) return;
+      setLanesControlElement(isAdded ? addedNode : null);
+    },
+    { childList: true },
+  );
+
+  return lanesControlElement;
+}
+
+export function useLaneGuidanceControl(lanesDirection: 'fwd' | 'rev') {
+  const lanesControlElement = useLaneGuidanceControlElement(lanesDirection);
+
+  return useMemo(
+    () => findLaneGuidanceControlModelByLanesControl(lanesControlElement),
+    [lanesControlElement],
+  );
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/main.tsx
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/main.tsx
@@ -1,0 +1,73 @@
+import { useOnRemove, usePreference, useTranslate } from '@/hooks';
+import {
+  isSegmentDirectionAllowed,
+  isSegmentConnectsToRoundabout,
+} from '@/utils/wme-entities/segment';
+import { useDebounceCallback } from 'usehooks-ts';
+import { SetTurnArrowsButton } from './components';
+import { FeatureDiscoverTooltip } from '@/components/FeatureDiscoverTooltip';
+import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
+import { useState } from 'react';
+
+interface MainProps {
+  segment: SegmentDataModel;
+}
+export default function Main({ segment }: MainProps) {
+  const [autoDiscoverBtn, setAutoDiscoverBtn] =
+    useState<HTMLButtonElement>(null);
+  const debouncedSetAutoDiscoverBtn = useDebounceCallback(
+    setAutoDiscoverBtn,
+    500,
+  );
+  useOnRemove(autoDiscoverBtn, () => setAutoDiscoverBtn(null));
+  const [isAutoDiscovered, setAutoDiscovered] = usePreference(
+    'feat_discovers.auto_roundabout_lane_guidance_turn_arrows',
+  );
+  const featDiscoverT = useTranslate('jb_utils.lanes.set_turn_arrows_fd');
+
+  return (
+    <>
+      {renderForDirection('fwd', debouncedSetAutoDiscoverBtn, segment)}
+      {renderForDirection('rev', debouncedSetAutoDiscoverBtn, segment)}
+      {!isAutoDiscovered && autoDiscoverBtn && (
+        <FeatureDiscoverTooltip
+          target={{ current: autoDiscoverBtn }}
+          placement="right-start"
+          headline={featDiscoverT('title')}
+          body={featDiscoverT('body')}
+          primaryButtonText={featDiscoverT('button')}
+          onPrimaryButtonClick={() => {
+            setAutoDiscoverBtn(null);
+            debouncedSetAutoDiscoverBtn(null);
+            setAutoDiscovered(true);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function renderForDirection(
+  direction: 'fwd' | 'rev',
+  setAutoDiscoverBtn: (button: HTMLButtonElement) => void,
+  segment: SegmentDataModel,
+) {
+  const fullDirection = (
+    {
+      fwd: 'forward',
+      rev: 'reverse',
+    } as const
+  )[direction];
+
+  if (!isSegmentDirectionAllowed(segment, fullDirection)) return null;
+  if (!isSegmentConnectsToRoundabout(segment, fullDirection)) return null;
+
+  return (
+    <SetTurnArrowsButton
+      lanesDirection={direction}
+      onTurnArrowsSetAutomatically={(event) =>
+        setAutoDiscoverBtn(event.detail.associatedButton)
+      }
+    />
+  );
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/models/index.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/models/index.ts
@@ -1,0 +1,6 @@
+export {
+  LaneGuidanceControlModel,
+  LaneGuidanceControlTurnModel,
+  isFarTurnLaneGuidanceControlModel,
+  isLaneGuidanceControlModel,
+} from './lane-guidance-control.model';

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/models/lane-guidance-control.model.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/models/lane-guidance-control.model.ts
@@ -1,0 +1,65 @@
+import {
+  LaneGuidanceInstructionStrategy,
+  LaneGuidanceMode,
+} from '@/@waze/Waze/enums';
+import { Collection, Model } from 'backbone';
+
+interface LaneGuidanceControlModelTurnAttr {
+  fromVertexID: string;
+  toVertexID: string;
+  streetName: string;
+  angle: number | null;
+  angleOverride: number | null;
+  checkboxes: Array<{
+    checked: boolean;
+    index: number;
+    uniqueId: string;
+  }>;
+  checkedIndexes: number[];
+  isFarTurn: boolean;
+  isUTurn: boolean;
+  guidanceMode: LaneGuidanceMode;
+  instructionStrategy: LaneGuidanceInstructionStrategy | null;
+}
+interface LaneGuidanceControlModelFarTurnAttr
+  extends LaneGuidanceControlModelTurnAttr {
+  isFarTurn: true;
+  farTurnAngle: number;
+}
+
+export type LaneGuidanceControlTurnModel<
+  T extends
+    | LaneGuidanceControlModelTurnAttr
+    | LaneGuidanceControlModelFarTurnAttr =
+    | LaneGuidanceControlModelTurnAttr
+    | LaneGuidanceControlModelFarTurnAttr,
+> = Model<T>;
+
+export type LaneGuidanceControlModel = Model<{
+  fromVertexID: string;
+  hasChanged: boolean;
+  hasCollisions: boolean;
+  hasGaps: boolean;
+  hasIllegalFarLanes: boolean;
+  laneCount: number;
+  farTurns: Collection<
+    LaneGuidanceControlTurnModel<LaneGuidanceControlModelFarTurnAttr>
+  >;
+  immediateTurns: Collection<LaneGuidanceControlTurnModel>;
+}>;
+
+export function isFarTurnLaneGuidanceControlModel(
+  model: LaneGuidanceControlTurnModel,
+): model is LaneGuidanceControlTurnModel<LaneGuidanceControlModelFarTurnAttr> {
+  return model.get('isFarTurn') === true;
+}
+
+export function isLaneGuidanceControlModel(
+  model: Model,
+): model is LaneGuidanceControlModel {
+  return (
+    'farTurns' in model.attributes &&
+    'immediateTurns' in model.attributes &&
+    'laneCount' in model.attributes
+  );
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/template.tsx
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/template.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { WazeMapEditorEntityType } from '@/@waze/Waze/consts';
+import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
+import { EditPanelTemplate } from '@/components/edit-panel/edit-panel-template';
+import {
+  isSegmentConnectsToRoundabout,
+  isSegmentDirectionAllowed,
+} from '@/utils/wme-entities/segment';
+import { ReactElement } from 'react';
+import { SetTurnArrowsButton } from './components';
+
+export class LaneGuidanceAutoTurnArrow implements EditPanelTemplate {
+  private readonly _segment: SegmentDataModel;
+
+  constructor(segments: SegmentDataModel[]) {
+    this._segment = segments[0];
+  }
+
+  static getSupportedElementTypes(): WazeMapEditorEntityType[] {
+    return [WazeMapEditorEntityType.Segment];
+  }
+
+  getTargetElement(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  static isEnabledForElements(segments: SegmentDataModel[]): boolean {
+    return segments.length === 1 && isSegmentConnectsToRoundabout(segments[0]);
+  }
+
+  render(): ReactElement[] {
+    return [
+      this.renderForDirection('rev'), // Node A
+      this.renderForDirection('fwd'), // Node B
+    ];
+  }
+
+  renderForDirection(direction: 'fwd' | 'rev'): ReactElement {
+    const fullDirection = (
+      {
+        fwd: 'forward',
+        rev: 'reverse',
+      } as const
+    )[direction];
+
+    if (!isSegmentDirectionAllowed(this._segment, fullDirection)) return null;
+    if (!isSegmentConnectsToRoundabout(this._segment, fullDirection))
+      return null;
+    return <SetTurnArrowsButton lanesDirection={direction} />;
+  }
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/template.tsx
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/template.tsx
@@ -2,15 +2,13 @@
 import { WazeMapEditorEntityType } from '@/@waze/Waze/consts';
 import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
 import { EditPanelTemplate } from '@/components/edit-panel/edit-panel-template';
-import {
-  isSegmentConnectsToRoundabout,
-  isSegmentDirectionAllowed,
-} from '@/utils/wme-entities/segment';
+import { isSegmentConnectsToRoundabout } from '@/utils/wme-entities/segment';
 import { ReactElement } from 'react';
-import { SetTurnArrowsButton } from './components';
+import MainComponent from './main';
 
 export class LaneGuidanceAutoTurnArrow implements EditPanelTemplate {
   private readonly _segment: SegmentDataModel;
+  private static readonly _targetEl = document.createElement('div');
 
   constructor(segments: SegmentDataModel[]) {
     this._segment = segments[0];
@@ -21,31 +19,14 @@ export class LaneGuidanceAutoTurnArrow implements EditPanelTemplate {
   }
 
   getTargetElement(): HTMLElement {
-    return document.createElement('div');
+    return LaneGuidanceAutoTurnArrow._targetEl;
   }
 
   static isEnabledForElements(segments: SegmentDataModel[]): boolean {
     return segments.length === 1 && isSegmentConnectsToRoundabout(segments[0]);
   }
 
-  render(): ReactElement[] {
-    return [
-      this.renderForDirection('rev'), // Node A
-      this.renderForDirection('fwd'), // Node B
-    ];
-  }
-
-  renderForDirection(direction: 'fwd' | 'rev'): ReactElement {
-    const fullDirection = (
-      {
-        fwd: 'forward',
-        rev: 'reverse',
-      } as const
-    )[direction];
-
-    if (!isSegmentDirectionAllowed(this._segment, fullDirection)) return null;
-    if (!isSegmentConnectsToRoundabout(this._segment, fullDirection))
-      return null;
-    return <SetTurnArrowsButton lanesDirection={direction} />;
+  render(): ReactElement {
+    return <MainComponent segment={this._segment} />;
   }
 }

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/find-lane-guidance-container.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/find-lane-guidance-container.ts
@@ -1,0 +1,18 @@
+const DIRECTION_TO_CLASS_MAP = {
+  fwd: 'fwd-lanes',
+  rev: 'rev-lanes',
+};
+
+export function findLaneGuidanceContainerByDirection(
+  direction: 'fwd' | 'rev',
+): Element {
+  return document
+    .getElementById('edit-panel')
+    .querySelector(
+      `.lanes .direction-lanes.${DIRECTION_TO_CLASS_MAP[direction]}`,
+    );
+}
+
+export function findLaneGuidanceEditRegionContainer(root: Element): Element {
+  return root.getElementsByClassName('edit-region')[0];
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/find-lane-guidance-control-model.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/find-lane-guidance-control-model.ts
@@ -1,0 +1,19 @@
+import { getReactFiberNode, getReactFiberState } from '@/utils/react-fiber';
+import {
+  LaneGuidanceControlModel,
+  isLaneGuidanceControlModel,
+} from '../models';
+import { isLanesControlElement } from './is-lanes-control-element';
+
+export function findLaneGuidanceControlModelByLanesControl(
+  lanesControlElement: Element,
+): LaneGuidanceControlModel {
+  if (!isLanesControlElement(lanesControlElement)) return null;
+  const fiber = getReactFiberNode(lanesControlElement);
+  const controlModelState = getReactFiberState<LaneGuidanceControlModel>(
+    fiber,
+    (state) => state.attributes && isLaneGuidanceControlModel(state),
+  );
+  if (!controlModelState) return null;
+  return controlModelState[0];
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/index.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/index.ts
@@ -1,0 +1,7 @@
+export {
+  findLaneGuidanceContainerByDirection,
+  findLaneGuidanceEditRegionContainer,
+} from './find-lane-guidance-container';
+export { findLaneGuidanceControlModelByLanesControl } from './find-lane-guidance-control-model';
+export { isLanesControlElement } from './is-lanes-control-element';
+export { setControlTurnArrows } from './set-control-turn-arrows';

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/is-lanes-control-element.spec.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/is-lanes-control-element.spec.ts
@@ -1,0 +1,46 @@
+import { isLanesControlElement } from './is-lanes-control-element';
+
+function fromHTML(html: string, trim = true) {
+  // Process the HTML string.
+  html = trim ? html.trim() : html;
+  if (!html) return null;
+
+  // Then set up a new template element.
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  const result = template.content.children;
+
+  // Then return either an HTMLElement or HTMLCollection,
+  // based on whether the input HTML had one or more roots.
+  if (result.length === 1) return result[0];
+  return result;
+}
+
+const validLanesControlHtmlString = `<div class="controls direction-lanes-edit">
+  <div class="form-group">
+    <label class="control-label">Number of Lanes</label>
+    <div class="controls-container">
+      <input class="form-control" max="32" min="0" name="laneCount" size="3" type="number" value="0">
+    </div>
+  </div>
+  <div class="button-container">
+    <wz-button color="secondary" size="sm" class="cancel-button">Cancel</wz-button>
+    <wz-button disabled="" size="sm" class="apply-button">Apply</wz-button>
+  </div>
+</div>`;
+
+const validLanesControlDomNode = fromHTML(
+  validLanesControlHtmlString,
+) as Element;
+
+describe('isLanesControlElement', () => {
+  it("should return true for an element with class 'lanes-control'", () => {
+    console.log(validLanesControlDomNode.className);
+    expect(isLanesControlElement(validLanesControlDomNode)).toBe(true);
+  });
+
+  it("should return false for an element without class 'lanes-control'", () => {
+    const element = document.createElement('div');
+    expect(isLanesControlElement(element)).toBe(false);
+  });
+});

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/is-lanes-control-element.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/is-lanes-control-element.ts
@@ -1,0 +1,7 @@
+export function isLanesControlElement(element: Element): boolean {
+  return (
+    element &&
+    element.classList.contains('controls') &&
+    element.classList.contains('direction-lanes-edit')
+  );
+}

--- a/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/set-control-turn-arrows.ts
+++ b/userscript/src/components/edit-panel/lg-auto-turn-arrow/utils/set-control-turn-arrows.ts
@@ -1,0 +1,80 @@
+import { CountryDataModel } from '@/@waze/Waze/DataModels/CountryDataModel';
+import {
+  LaneGuidanceControlModel,
+  LaneGuidanceControlTurnModel,
+} from '@/components/edit-panel/lg-auto-turn-arrow/models';
+import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+import { getSegmentByVertex } from '@/utils/location';
+import { getSegmentHeadingByDirection } from '@/utils/wme-entities/segment';
+import { createVertexById } from '@/utils/wme-entities/segment-vertex';
+
+const arrowStyleStopPoints = [
+  { styleAngle: 135, stopPoint: 67.5 },
+  { styleAngle: 90, stopPoint: 112.5 },
+  { styleAngle: 45, stopPoint: 157.5 },
+  { styleAngle: 0, stopPoint: 202.5 },
+  { styleAngle: -45, stopPoint: 247.5 },
+  { styleAngle: -90, stopPoint: 292.5 },
+  { styleAngle: -135, stopPoint: 360 },
+];
+
+function isUTurn(turnModel: LaneGuidanceControlTurnModel): boolean {
+  const fromVertex = createVertexById(turnModel.get('fromVertexID'));
+  const toVertex = createVertexById(turnModel.get('toVertexID'));
+  if (fromVertex.getOpposite().equals(toVertex)) return true;
+
+  const dataModel = getWazeMapEditorWindow().W.model;
+  const fromSegment = getSegmentByVertex(dataModel, fromVertex);
+  const toSegment = getSegmentByVertex(dataModel, toVertex);
+  const fromSegmentAddress = fromSegment.getAddress().format();
+  const toSegmentAddress = toSegment.getAddress().format();
+  const isAddressEquals = fromSegmentAddress === toSegmentAddress;
+  const fromSegmentRoadType = fromSegment.getAttribute('roadType');
+  const toSegmentRoadType = toSegment.getAttribute('roadType');
+
+  if (fromSegmentRoadType === toSegmentRoadType) {
+    if (
+      (isAddressEquals || fromSegmentRoadType === toSegmentRoadType) &&
+      getSegmentHeadingByDirection(
+        fromSegment,
+        fromVertex.getOpposite().direction,
+      ) === getSegmentHeadingByDirection(toSegment, toVertex.direction)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getArrowAngleByTurnAngle(
+  turnAngle: number,
+  uTurnArrowAngle: number,
+): number {
+  const normalizedFarTurnAngle =
+    turnAngle > 0 ? 180 - turnAngle : Math.abs(turnAngle - 180);
+  for (const arrowStyleStopPoint of arrowStyleStopPoints) {
+    if (normalizedFarTurnAngle < arrowStyleStopPoint.stopPoint)
+      return arrowStyleStopPoint.styleAngle;
+  }
+  return uTurnArrowAngle;
+}
+
+export function setControlTurnArrows(control: LaneGuidanceControlModel) {
+  const topCountry: CountryDataModel =
+    getWazeMapEditorWindow().W.model.getTopCountry();
+  const isLeftHandTraffic = topCountry.getAttribute('leftHandTraffic');
+  const uTurnArrowAngle = isLeftHandTraffic ? 180 : -180;
+  const farTurns = control.get('farTurns');
+  farTurns.forEach((farTurn) => {
+    const farTurnAngle = farTurn.get('farTurnAngle');
+    if (isUTurn(farTurn)) farTurn.set('angleOverride', uTurnArrowAngle);
+    else {
+      const mappedArrowAngle = getArrowAngleByTurnAngle(
+        farTurnAngle,
+        uTurnArrowAngle,
+      );
+      farTurn.set('angleOverride', mappedArrowAngle);
+    }
+  });
+}

--- a/userscript/src/components/preferences/PreferencesContent.tsx
+++ b/userscript/src/components/preferences/PreferencesContent.tsx
@@ -2,6 +2,7 @@ import { AutoBackupToggle } from './AutoBackupToggle';
 import { DisableScriptToggle } from './DisableScriptToggle';
 import { TogglePrefsLocationButton } from './TogglePrefsLocationButton';
 import { CloneGeometryToggle } from './roundabout/CloneGeometryToggle';
+import { LaneGuidanceInferArrows } from './roundabout/LaneGuidanceInferArrows';
 
 export function PreferencesContent() {
   return (
@@ -18,6 +19,7 @@ export function PreferencesContent() {
       </div>
       <CloneGeometryToggle />
       <AutoBackupToggle />
+      <LaneGuidanceInferArrows />
     </>
   );
 }

--- a/userscript/src/components/preferences/roundabout/LaneGuidanceInferArrows.tsx
+++ b/userscript/src/components/preferences/roundabout/LaneGuidanceInferArrows.tsx
@@ -4,7 +4,7 @@ import { WzCheckbox } from '@wazespace/wme-react-components';
 export function LaneGuidanceInferArrows() {
   const t = useTranslate('jb_utils.user.prefs');
   const [preference, setPreference] = usePreference(
-    'auto_set_roundabuot_lane_guidance_turn_arrows',
+    'auto_set_roundabout_lane_guidance_turn_arrows',
   );
   const isEnabled = preference === true;
 

--- a/userscript/src/components/preferences/roundabout/LaneGuidanceInferArrows.tsx
+++ b/userscript/src/components/preferences/roundabout/LaneGuidanceInferArrows.tsx
@@ -1,0 +1,25 @@
+import { usePreference, useTranslate } from '@/hooks';
+import { WzCheckbox } from '@wazespace/wme-react-components';
+
+export function LaneGuidanceInferArrows() {
+  const t = useTranslate('jb_utils.user.prefs');
+  const [preference, setPreference] = usePreference(
+    'auto_set_roundabuot_lane_guidance_turn_arrows',
+  );
+  const isEnabled = preference === true;
+
+  return (
+    <div className="form-group">
+      <WzCheckbox
+        checked={isEnabled}
+        onChange={(e) => setPreference((e.target as HTMLInputElement).checked)}
+        style={{
+          display: 'inline-block',
+          marginInlineEnd: '4px',
+        }}
+      >
+        {t('infer_roundabout_lane_guidance_turn_arrows')}
+      </WzCheckbox>
+    </div>
+  );
+}

--- a/userscript/src/hooks/index.ts
+++ b/userscript/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useSyncEffect';
 export * from './useInjectTranslations';
 export * from './useMutationObserver';
 export { useVersionDependantConfig } from './useVersionDependantConfig';
+export { useOnRemove } from './useOnRemove';

--- a/userscript/src/hooks/useMutationObserver.ts
+++ b/userscript/src/hooks/useMutationObserver.ts
@@ -11,6 +11,7 @@ export function useMutationObserver(
 
   const observeTarget = useCallback(() => {
     if (!observer.current) return;
+    if (!target) return;
     observer.current.observe(target, options);
   }, [options, target]);
   const disconnectTarget = useCallback(() => {

--- a/userscript/src/hooks/useOnRemove.ts
+++ b/userscript/src/hooks/useOnRemove.ts
@@ -1,0 +1,19 @@
+import { useMutationObserver } from './useMutationObserver';
+
+export function useOnRemove(element: Element, callback: () => void) {
+  useMutationObserver(
+    element?.parentElement,
+    (mutations, observer) => {
+      for (const mutation of mutations) {
+        const removedNodes = Array.from(mutation.removedNodes);
+        for (const el of removedNodes) {
+          if (el === element) {
+            callback();
+            observer.disconnect();
+          }
+        }
+      }
+    },
+    { childList: true },
+  );
+}

--- a/userscript/src/hooks/usePreferences.ts
+++ b/userscript/src/hooks/usePreferences.ts
@@ -65,7 +65,7 @@ export function useSetPreference<K extends FlattenKeys<Preferences>>(
   const setPreferenceValue = (
     value?: SetStateAction<GetNestedType<Preferences, K>>,
   ): void => {
-    return dispatch(createSetPreferenceAction(key, value || defaultValue));
+    dispatch(createSetPreferenceAction(key, value || defaultValue));
   };
   return setPreferenceValue;
 }

--- a/userscript/src/hooks/usePreferences.ts
+++ b/userscript/src/hooks/usePreferences.ts
@@ -56,3 +56,16 @@ export function usePreference<K extends FlattenKeys<Preferences>>(key: K) {
 
   return [preferenceValue, setPreferenceValue] as const;
 }
+
+export function useSetPreference<K extends FlattenKeys<Preferences>>(
+  key: K,
+  defaultValue: SetStateAction<GetNestedType<Preferences, K>>,
+) {
+  const [, dispatch] = usePreferences();
+  const setPreferenceValue = (
+    value?: SetStateAction<GetNestedType<Preferences, K>>,
+  ): void => {
+    return dispatch(createSetPreferenceAction(key, value || defaultValue));
+  };
+  return setPreferenceValue;
+}

--- a/userscript/src/preferences/prefs-data.ts
+++ b/userscript/src/preferences/prefs-data.ts
@@ -8,8 +8,10 @@ export type Preferences = {
     };
   };
   auto_backup: boolean;
+  auto_set_roundabuot_lane_guidance_turn_arrows: boolean;
   feat_discovers: {
     auto_restore: boolean;
+    auto_roundabout_lane_guidance_turn_arrows: boolean;
   };
 };
 
@@ -23,8 +25,10 @@ export const defaultPreferences: Preferences = {
     },
   },
   auto_backup: true,
+  auto_set_roundabuot_lane_guidance_turn_arrows: true,
   feat_discovers: {
     auto_restore: false,
+    auto_roundabout_lane_guidance_turn_arrows: false,
   },
 };
 

--- a/userscript/src/preferences/prefs-data.ts
+++ b/userscript/src/preferences/prefs-data.ts
@@ -8,7 +8,7 @@ export type Preferences = {
     };
   };
   auto_backup: boolean;
-  auto_set_roundabuot_lane_guidance_turn_arrows: boolean;
+  auto_set_roundabout_lane_guidance_turn_arrows: boolean;
   feat_discovers: {
     auto_restore: boolean;
     auto_roundabout_lane_guidance_turn_arrows: boolean;
@@ -25,7 +25,7 @@ export const defaultPreferences: Preferences = {
     },
   },
   auto_backup: true,
-  auto_set_roundabuot_lane_guidance_turn_arrows: true,
+  auto_set_roundabout_lane_guidance_turn_arrows: true,
   feat_discovers: {
     auto_restore: false,
     auto_roundabout_lane_guidance_turn_arrows: false,

--- a/userscript/src/resources/localization/userscript.json
+++ b/userscript/src/resources/localization/userscript.json
@@ -28,7 +28,8 @@
             }
           }
         },
-        "auto_backup_on_delete": "Automatically backup junction boxes"
+        "auto_backup_on_delete": "Automatically backup junction boxes",
+        "infer_roundabout_lane_guidance_turn_arrows": "Infer turn arrows for roundabout"
       }
     },
     "segment": {

--- a/userscript/src/resources/localization/userscript.json
+++ b/userscript/src/resources/localization/userscript.json
@@ -97,6 +97,14 @@
       "roundabout": {
         "title": "Roundabout"
       }
+    },
+    "lanes": {
+      "set_turn_arrows": "Set turn arrows",
+      "set_turn_arrows_fd": {
+        "title": "Auto Turn Arrows",
+        "body": "Junction Box Utils automatically infers turn arrows for roundabouts, saving you time.\nYou can disable this feature in settings.",
+        "button": "Got it"
+      }
     }
   },
   "save": {

--- a/userscript/src/utils/create-react-portal.ts
+++ b/userscript/src/utils/create-react-portal.ts
@@ -6,11 +6,11 @@ interface PortalProps {
   children: ReactNode;
   portalKey?: string;
 }
-export function createReactPortal(
-  getContainer: () => Element | DocumentFragment,
-): ComponentType<PortalProps> {
-  return ({ children, portalKey }: PortalProps) => {
-    const container = useMemo(() => getContainer(), []);
+export function createReactPortal<P extends object = Record<string, never>>(
+  getContainer: (props: P) => Element | DocumentFragment,
+): ComponentType<PortalProps & P> {
+  return ({ children, portalKey, ...rest }: PortalProps & P) => {
+    const container = useMemo(() => getContainer(rest as P), [rest]);
     if (!container) {
       Logger.error(
         '[createReactPortal] Unable to resolve to a container from a retriever function',

--- a/userscript/src/utils/dom-node.spec.ts
+++ b/userscript/src/utils/dom-node.spec.ts
@@ -1,0 +1,18 @@
+import { isElementNode } from './dom-node';
+
+describe('isElementNode', () => {
+  it('should return true for an element node', () => {
+    const element = document.createElement('div');
+    expect(isElementNode(element)).toBe(true);
+  });
+
+  it('should return false for a text node', () => {
+    const textNode = document.createTextNode('Hello');
+    expect(isElementNode(textNode)).toBe(false);
+  });
+
+  it('should return false for a comment node', () => {
+    const commentNode = document.createComment('This is a comment');
+    expect(isElementNode(commentNode)).toBe(false);
+  });
+});

--- a/userscript/src/utils/dom-node.ts
+++ b/userscript/src/utils/dom-node.ts
@@ -1,0 +1,3 @@
+export function isElementNode(node: Node): node is Element {
+  return node.nodeType === node.ELEMENT_NODE;
+}

--- a/userscript/src/utils/react-fiber/get-react-fiber-state.ts
+++ b/userscript/src/utils/react-fiber/get-react-fiber-state.ts
@@ -1,0 +1,38 @@
+import { Dispatch, SetStateAction } from 'react';
+import { Fiber } from 'react-reconciler';
+import { getReactFiberNode } from './get-react-fiber-node';
+
+export function getReactFiberState<S>(
+  fiber: Fiber,
+  predicate: (value: any, index: number) => boolean,
+): [S, Dispatch<SetStateAction<S>>] | null {
+  let currentStateNode = fiber.memoizedState;
+  let currentStateNodeIndex = 0;
+
+  while (currentStateNode) {
+    if (!currentStateNode.queue) {
+      // probably is a useEffect or something similar, but it's probably not a state
+      currentStateNode = currentStateNode.next;
+      continue;
+    }
+
+    const currentState = currentStateNode.queue.lastRenderedState;
+    const dispatchState = currentStateNode.queue.dispatch;
+    if (predicate(currentState, currentStateNodeIndex))
+      return [currentState, dispatchState];
+
+    currentStateNode = currentStateNode.next;
+    currentStateNodeIndex++;
+  }
+
+  return null;
+}
+
+export function getReactFiberStateByDomElement<S>(
+  element: Element,
+  predicate: (value: any, index: number) => boolean,
+) {
+  const fiberNode = getReactFiberNode(element);
+  if (!fiberNode) return null;
+  return getReactFiberState<S>(fiberNode, predicate);
+}

--- a/userscript/src/utils/react-fiber/index.ts
+++ b/userscript/src/utils/react-fiber/index.ts
@@ -1,3 +1,4 @@
 export * from './find-fiber-parent-node';
 export * from './get-react-fiber-node';
+export * from './get-react-fiber-state';
 export * from './is-react-provider-node';

--- a/userscript/src/utils/wme-entities/segment-vertex.ts
+++ b/userscript/src/utils/wme-entities/segment-vertex.ts
@@ -40,3 +40,10 @@ export function createForwardVertexFromSegment(segment: SegmentDataModel) {
 export function createReverseVertexFromSegment(segment: SegmentDataModel) {
   return createVertexFromSegment(segment, 'reverse');
 }
+
+export function createVertexById(vertexId: string): Vertex {
+  const segmentId = parseInt(vertexId.substring(0, vertexId.length - 1));
+  const direction =
+    vertexId[vertexId.length - 1] === 'f' ? 'forward' : 'reverse';
+  return createVertex(segmentId, direction);
+}

--- a/userscript/src/utils/wme-entities/segment.ts
+++ b/userscript/src/utils/wme-entities/segment.ts
@@ -111,3 +111,12 @@ export function getSegmentFromNodeInTravelDirection(
     getSegmentTravelDirection(segment) === 'forward' ? 'reverse' : 'forward',
   );
 }
+
+export function getSegmentHeadingByDirection(
+  segment: SegmentDataModel,
+  direction: 'fwd' | 'rev' | 'forward' | 'reverse',
+): number {
+  if (direction === 'fwd' || direction === 'forward')
+    return segment.getFwdHeading();
+  return segment.getRevHeading();
+}


### PR DESCRIPTION
Following a feature request submitted by [reuvenirony](https://waze.com/user/editor/reuvenirony), a new button is now added to the lane guidance control panel when configuring lanes in roundabouts. Clicking the button will automatically set the turn arrows in the lane guidance according to the following diagram
![image](https://github.com/WazeSpace/wme-junction-box-utils/assets/21009377/b8777676-29a2-4675-adf4-68d2e80d52e5)
This diagram does not specify the angles for the U-Turn because. Instead, the code will check the departing segment heading to be opposite the entrance segment (north-south, west-east, etc.) and compare the address or the segment type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced automatic turn arrow setting based on lane guidance controls.
	- Added lane guidance mode and instruction strategy options.
	- Implemented new preferences for roundabout lane guidance turn arrows.
	- Enhanced preference management with new hooks.

- **Bug Fixes**
	- Improved mutation observer to prevent errors when the target is undefined.

- **Documentation**
	- Updated preferences documentation with new boolean properties for lane guidance.

- **Refactor**
	- Streamlined lane guidance control models and utility functions for better performance.

- **Chores**
	- Structured new components and hooks for lane guidance and turn arrow settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->