### PR TITLE
feat(JBU-52): enable redrawing big junctions

### DIFF
--- a/userscript/src/components/background-actions/BackgroundActions.tsx
+++ b/userscript/src/components/background-actions/BackgroundActions.tsx
@@ -1,3 +1,4 @@
+import { EnlargeBigJunction } from '@/components/background-actions/actions/EnlargeBigJunction';
 import { ReactElement } from 'react';
 import { AutoCloneRoundaboutGeometryBackgroundAction } from './actions/AutoCloneRoundaboutGeom';
 import { AutoBackupBigJunctionBeforeDelete } from './actions/AutoBackupBigJunctionBeforeDelete';
@@ -9,6 +10,7 @@ export function BackgroundActions(): ReactElement {
       <AutoCloneRoundaboutGeometryBackgroundAction />
       <AutoBackupBigJunctionBeforeDelete />
       <AutoRestoreBigJunction />
+      <EnlargeBigJunction />
     </>
   );
 }

--- a/userscript/src/components/background-actions/actions/EnlargeBigJunction.tsx
+++ b/userscript/src/components/background-actions/actions/EnlargeBigJunction.tsx
@@ -1,0 +1,83 @@
+import {
+  Action,
+  isAddBigJunctionAction,
+  MultiAction,
+} from '@/@waze/Waze/actions';
+import { BigJunctionDataModel } from '@/@waze/Waze/DataModels/BigJunctionDataModel';
+import { SegmentDataModel } from '@/@waze/Waze/DataModels/SegmentDataModel';
+import { BigJunctionBackup } from '@/components/edit-panel/big-junction-backup';
+import { RestoreBigJunctionBackupAction } from '@/components/edit-panel/big-junction-backup/actions';
+import { ManualMethodInvocationInterceptor } from '@/method-interceptor';
+import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
+import { createDeleteBigJunctionAction } from '@/utils/wme-feature-destroyer';
+import { useEffect, useMemo } from 'react';
+import { useEventCallback } from 'usehooks-ts';
+
+function getAllBigJunctions(): BigJunctionDataModel[] {
+  return getWazeMapEditorWindow().W.model.bigJunctions.getObjectArray();
+}
+
+export function EnlargeBigJunction() {
+  const onBeforeActionAdded = useEventCallback(
+    (addAction: (action: Action) => void, action: Action) => {
+      if (!isAddBigJunctionAction(action)) return addAction(action);
+
+      // find another big junction with all its segments exist in the new big junction
+      const newBigJunctionSegIDs = new Set<number>(
+        (action as any)
+          ._findShortSegments(getWazeMapEditorWindow().W.model)
+          .map((segment: SegmentDataModel) => segment.getAttribute('id')),
+      );
+      const deprecatedBigJunction = getAllBigJunctions().find((bigJunction) => {
+        const bigJunctionSegments = bigJunction.getAttribute('segIDs');
+        return bigJunctionSegments.every((segID) =>
+          newBigJunctionSegIDs.has(segID),
+        );
+      });
+      if (!deprecatedBigJunction || deprecatedBigJunction.state === 'DELETE')
+        return addAction(action);
+
+      const deleteBigJunctionAction = createDeleteBigJunctionAction(
+        deprecatedBigJunction,
+      );
+      const bigJunctionSnapshot = BigJunctionBackup.fromBigJunction(
+        deprecatedBigJunction,
+      );
+
+      const newBigJunctionRestoreAction = new RestoreBigJunctionBackupAction(
+        action.bigJunction,
+        bigJunctionSnapshot,
+        [],
+      );
+
+      const multiWrapper = new MultiAction([
+        deleteBigJunctionAction,
+        action,
+        newBigJunctionRestoreAction,
+      ]);
+      multiWrapper.generateDescription = (model) => {
+        action.generateDescription(model);
+        (multiWrapper as any)._description = (action as any)._description;
+      };
+
+      addAction(multiWrapper);
+    },
+  );
+
+  const beforeActionAddedInterceptor = useMemo(
+    () =>
+      new ManualMethodInvocationInterceptor(
+        getWazeMapEditorWindow().W.model.actionManager,
+        'add',
+        onBeforeActionAdded,
+      ),
+    [onBeforeActionAdded],
+  );
+
+  useEffect(() => {
+    beforeActionAddedInterceptor.enable();
+    return () => beforeActionAddedInterceptor.disable();
+  }, [beforeActionAddedInterceptor]);
+
+  return null;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new component, `EnlargeBigJunction`, to enhance the management of big junctions within the Waze map editor.
	- Added functionality to intercept and handle actions related to adding big junctions, improving state coherence and preventing conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->