### PR TITLE
feat: implement useSidebarTabPane hook and integrate into Preferences

### DIFF
--- a/userscript/src/hooks/index.ts
+++ b/userscript/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './usePreferences';
+export * from './useSidebarTabPane';
 export * from './useTranslate';
 export * from './useSyncEffect';
 export * from './useInjectTranslations';

--- a/userscript/src/hooks/useSidebarTabPane.ts
+++ b/userscript/src/hooks/useSidebarTabPane.ts
@@ -36,7 +36,7 @@ export function useSidebarTabPane(tabType: SidebarTabPaneType): Element | null {
     return () => {
       unsubscribe();
     }
-  }, [wmeSdk]);
+  }, [tabType]);
 
   return tabPane;
 }

--- a/userscript/src/hooks/useSidebarTabPane.ts
+++ b/userscript/src/hooks/useSidebarTabPane.ts
@@ -1,0 +1,42 @@
+import { wmeSdk } from '@/utils/wme-sdk';
+import { useEffect, useState } from 'react';
+
+type SidebarTabPaneType = 'select' | 'solve' | 'events' | 'drives' | 'areas' | 'settings';
+
+const tabTypeToDomIdMap: Record<SidebarTabPaneType, string> = {
+  select: 'edit-panel',
+  solve: 'sidepanel-issue-tracker',
+  events: 'sidepanel-mtes',
+  drives: 'sidepanel-drives',
+  areas: 'sidepanel-areas',
+  settings: 'sidepanel-prefs',
+}
+
+function getMountedTabPane(tabType: SidebarTabPaneType): Element | null {
+  const domId = tabTypeToDomIdMap[tabType];
+  return document.getElementById(domId);
+}
+
+export function useSidebarTabPane(tabType: SidebarTabPaneType): Element | null {
+  const [tabPane, setTabPane] = useState<Element | null>(() => getMountedTabPane(tabType));
+
+  useEffect(() => {
+    setTabPane(getMountedTabPane(tabType));
+  }, [tabType]);
+
+  useEffect(() => {
+    const unsubscribe = wmeSdk.Events.on({
+      eventName: 'wme-sidebar-tab-opened',
+      eventHandler: (e: { tabType: string, tabElement: Element }) => {
+        if (tabType !== e.tabType) return;
+        setTabPane(e.tabElement);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    }
+  }, [wmeSdk]);
+
+  return tabPane;
+}

--- a/userscript/webpack.config.js
+++ b/userscript/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = () => {
           require: [
             packageInfo.useWazeSpace &&
               'https://wazespace.github.io/userscripts-lib/index.js',
-            'https://cdn.jsdelivr.net/gh/WazeSpace/wme-sdk-plus@v1/wme-sdk-plus.js',
+            'https://cdn.jsdelivr.net/gh/WazeSpace/wme-sdk-plus@v1.3/wme-sdk-plus.js',
           ].filter(Boolean),
         },
         metajs: true,


### PR DESCRIPTION
… component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preferences rendering now adapts to the selected location, supporting display in both a sidebar tab and the WME settings pane with proper initialization and cleanup.
  * Added hook-based sidebar tab tracking to manage and synchronize the active sidebar tab element in real time.

* **Chores**
  * Updated external SDK dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->