### PR TITLE
fix: render only truly unverified turns in RestoreContext

### DIFF
--- a/userscript/src/components/edit-panel/big-junction-backup/contexts/RestoreContext.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/contexts/RestoreContext.tsx
@@ -101,24 +101,12 @@ export function RestoreContextProvider(props: RestoreContextProps) {
         isBackupRestored,
         hasJunctionNewTurns,
         unverifiedTurns: getBigJunctionTurns(targetBigJunction).filter(
-          (turn) => {
-            if (!turn.isFarTurn()) return false;
-            if (
-              Reflect.getMetadata(
-                UNVERIFIED_TURN_METADATA_SYMBOL,
-                turn.getTurnData(),
-              ) === true
-            ) {
-              return true;
-            }
-            if (isBackupRestored && backup) {
-              const turnExistsInBackup = backup
-                .getTurns()
-                .some((t) => t.getID() === turn.getID());
-              return !turnExistsInBackup;
-            }
-            return false;
-          },
+          (turn) =>
+            turn.isFarTurn() &&
+            Reflect.getMetadata(
+              UNVERIFIED_TURN_METADATA_SYMBOL,
+              turn.getTurnData(),
+            ) === true,
         ),
         restore: restoreCurrentBackup,
       }}


### PR DESCRIPTION
The issue arises from a wrongfully added validation in the RestoreContext that was intended to be a safe-guard and ensure that additional turns which are not part of the backup are marked as unverified for rendering, which caused all extended turns to be marked as such because technically they do not exist in the backup.

The fix was simple: remove that redundant check. This might cause truly new paths to not be shown as unverified, but this is actually the desired behavior since unverified means we did restore some of the turn, but you need to take a look, while a truly new turn is obvious to the user that he needs to take a look at it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined unverified turn handling during backup restoration to improve accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->