### PR TITLE
refactor: migrate TippyAtPoint to WME SDK

### DIFF
--- a/userscript/src/components/tippy/TippyAtMapEntity.tsx
+++ b/userscript/src/components/tippy/TippyAtMapEntity.tsx
@@ -13,7 +13,6 @@ interface TippyAtMapEntityProps
   extends Omit<ComponentProps<typeof TippyAtPoint>, 'point'> {
   entity: DataModel<DataModelAttributes & { geoJSONGeometry: Geometry }>;
   centerType?: 'normal' | 'mass';
-  map?: any;
 }
 
 export function TippyAtMapEntity(props: TippyAtMapEntityProps) {

--- a/userscript/src/components/tippy/TippyAtPoint.tsx
+++ b/userscript/src/components/tippy/TippyAtPoint.tsx
@@ -1,4 +1,3 @@
-import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
 import { getClientRectByPoint } from '@/utils/map';
 import Tippy from '@tippyjs/react';
 import { Point } from '@turf/helpers';
@@ -8,26 +7,14 @@ import { TippyModal } from './TippyModal';
 
 interface TippyAtPointProps extends ComponentProps<typeof Tippy> {
   point: Point | (() => Point);
-  map?: any;
 }
 
 export function TippyAtPoint(props: TippyAtPointProps) {
-  const { point, map = getWazeMapEditorWindow().W.map, ...restProps } = props;
+  const { point, ...restProps } = props;
 
   const getRefClientRect = useCallback(() => {
-    const mapViewportEl: Element = map.getViewport();
-    const mapBoundingRect = mapViewportEl.getBoundingClientRect();
-    const rectangle = getClientRectByPoint(
-      typeof point === 'function' ? point() : point,
-      map,
-    );
-
-    return {
-      ...rectangle.toJSON(),
-      left: rectangle.left + mapBoundingRect.x,
-      top: rectangle.top + mapBoundingRect.y,
-    };
-  }, [map, point]);
+    return getClientRectByPoint(typeof point === 'function' ? point() : point);
+  }, [point]);
 
   return (
     <TippyModal getReferenceClientRect={getRefClientRect} {...restProps} />

--- a/userscript/src/utils/map/get-client-rect-by-point.ts
+++ b/userscript/src/utils/map/get-client-rect-by-point.ts
@@ -1,11 +1,17 @@
 import { Point } from '@turf/helpers';
-import { getWazeMapEditorWindow } from '../get-wme-window';
+import { WmeSDK } from 'wme-sdk-typings';
+import { wmeSdk } from '../wme-sdk';
 
 export function getClientRectByPoint(
   coords: Point,
-  map = getWazeMapEditorWindow().W.map,
+  sdk: WmeSDK = wmeSdk,
 ): DOMRect {
   const [lon, lat] = coords.coordinates;
-  const pixel = map.getPixelFromLonLat({ lon, lat });
+  const pixel = sdk.Map.getPixelFromLonLat({
+    lonLat: {
+      lat,
+      lon,
+    },
+  });
   return new DOMRect(pixel.x, pixel.y, 1, 1);
 }


### PR DESCRIPTION
Since the internal `WMEMap` doesn't give us the viewport element, this also fixes a bug of the `TippyAtPoint` crashing the script with an uncaught exception regarding the inability to access that same viewport.

The SDK supports natively converting map coordinates to *screen* pixel (rather than to *map pixel* as our legacy implementation did).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified component prop types by removing unused parameters.
  * Updated utility function to use dependency injection pattern instead of window globals, improving code modularity and testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->