### PR TITLE
fix: resolve unverified turns layer stacking order

### DIFF
--- a/userscript/src/components/edit-panel/big-junction-backup/components/TurnsListView.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/TurnsListView.tsx
@@ -36,6 +36,8 @@ interface TurnsListViewProps {
   turns: Turn[];
   showFromStreet?: boolean;
   turnsHighlightRenderer: TurnsRenderer;
+  onHighlightActive?: () => void;
+  onHighlightInactive?: () => void;
 }
 export function TurnsListView({
   title,
@@ -43,12 +45,16 @@ export function TurnsListView({
   turns,
   showFromStreet = false,
   turnsHighlightRenderer,
+  onHighlightActive,
+  onHighlightInactive,
 }: TurnsListViewProps) {
   const onEntryMouseOver = (turn: Turn) => {
+    onHighlightActive?.();
     turnsHighlightRenderer.highlightTurn(turn);
   };
   const onEntryMouseOut = () => {
     turnsHighlightRenderer.clearHighlightedTurns();
+    onHighlightInactive?.();
   };
 
   return (

--- a/userscript/src/components/edit-panel/big-junction-backup/components/UnverifiedTurnsListView.tsx
+++ b/userscript/src/components/edit-panel/big-junction-backup/components/UnverifiedTurnsListView.tsx
@@ -3,7 +3,7 @@ import { TurnsListView } from './TurnsListView';
 import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
 import { useMemo } from 'react';
 import { TurnsRenderer } from '@/classes';
-import { useTranslate } from '@/hooks';
+import { useTranslate, useHighlightLayerController } from '@/hooks';
 
 export function UnverifiedTurnsListView() {
   const t = useTranslate(
@@ -17,6 +17,8 @@ export function UnverifiedTurnsListView() {
     return new TurnsRenderer(dataModel, map, turnsHighlightLayer);
   }, [dataModel, map, turnsHighlightLayer]);
 
+  const { elevate, restore } = useHighlightLayerController(turnsHighlightLayer);
+
   if (!unverifiedTurns.length) return null;
 
   return (
@@ -26,6 +28,8 @@ export function UnverifiedTurnsListView() {
       turns={unverifiedTurns}
       showFromStreet
       turnsHighlightRenderer={turnsHighlightRenderer}
+      onHighlightActive={elevate}
+      onHighlightInactive={restore}
     />
   );
 }

--- a/userscript/src/hooks/index.ts
+++ b/userscript/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useInjectTranslations';
 export * from './useMutationObserver';
 export { useVersionDependantConfig } from './useVersionDependantConfig';
 export { useOnRemove } from './useOnRemove';
+export * from './useHighlightLayerController';

--- a/userscript/src/hooks/useHighlightLayerController.ts
+++ b/userscript/src/hooks/useHighlightLayerController.ts
@@ -1,0 +1,38 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+export function useHighlightLayerController(layer: any) {
+  const originalStylesRef = useRef<{ zIndex: string; pointerEvents: string } | null>(null);
+
+  const restore = useCallback(() => {
+    if (!layer || !originalStylesRef.current) return;
+    const layerDiv = layer.div || document.getElementById(layer.id);
+    if (layerDiv) {
+      layerDiv.style.zIndex = originalStylesRef.current.zIndex;
+      layerDiv.style.pointerEvents = originalStylesRef.current.pointerEvents;
+    }
+    originalStylesRef.current = null;
+  }, [layer]);
+
+  const elevate = useCallback(() => {
+    if (!layer) return;
+    const layerDiv = layer.div || document.getElementById(layer.id);
+    if (layerDiv) {
+      if (!originalStylesRef.current) {
+        originalStylesRef.current = {
+          zIndex: layerDiv.style.zIndex || '',
+          pointerEvents: layerDiv.style.pointerEvents || '',
+        };
+      }
+      layerDiv.style.zIndex = '9999';
+      layerDiv.style.pointerEvents = 'none';
+    }
+  }, [layer]);
+
+  useEffect(() => {
+    return () => {
+      restore();
+    };
+  }, [restore]);
+
+  return { elevate, restore };
+}


### PR DESCRIPTION
Fixes a bug where the highlighted path for unverified turns was rendered underneath the native modified features layer.

Introduces a custom React hook `useHighlightLayerController` that dynamically elevates the highlight layer container's `zIndex` to `9999` and sets `pointerEvents` to `none` during hovers. This makes the path render on top of the modified map features layer while remaining fully click-through, ensuring the user can still select map features underneath the highlighted path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hover interactions for turns list with improved visual feedback coordination when selecting or interacting with list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->