### PR TITLE
refactor: safely resolve street in pullRoadshieldsMethod

### DIFF
--- a/userscript/jest.config.json
+++ b/userscript/jest.config.json
@@ -1,3 +1,6 @@
 {
-  "testEnvironment": "jsdom"
+  "testEnvironment": "jsdom",
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/src/$1"
+  }
 }

--- a/userscript/src/instruction-application-engine/methods/pull-roadshields-method.spec.ts
+++ b/userscript/src/instruction-application-engine/methods/pull-roadshields-method.spec.ts
@@ -1,0 +1,169 @@
+import pullRoadshieldsMethod from './pull-roadshields-method';
+import { getSegmentByVertex, getStreetBySegment } from '@/utils/location';
+import { createTurnGuidance } from '@/utils/wme-entities/turn-guidance';
+
+jest.mock('@/utils/get-wme-window', () => ({
+  getWazeMapEditorWindow: jest.fn(() => ({
+    W: {
+      model: {
+        roadGraph: {}
+      }
+    }
+  }))
+}));
+
+jest.mock('@/utils/location', () => ({
+  getSegmentByVertex: jest.fn(),
+  getStreetBySegment: jest.fn()
+}));
+
+jest.mock('@/utils/wme-entities/turn-guidance', () => ({
+  createTurnGuidance: jest.fn((data) => data)
+}));
+
+describe('pullRoadshieldsMethod', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockGetSegmentByVertex = getSegmentByVertex as jest.Mock;
+  const mockGetStreetBySegment = getStreetBySegment as jest.Mock;
+  const mockCreateTurnGuidance = createTurnGuidance as jest.Mock;
+
+  function createMockTurn(options: {
+    hasTurnGuidance: boolean;
+    streetName?: string | null;
+    signText?: string | null;
+    signType?: number;
+  }) {
+    const mockTurnData = {
+      hasTurnGuidance: jest.fn(() => options.hasTurnGuidance),
+      withTurnGuidance: jest.fn().mockReturnThis()
+    };
+
+    const mockTurn = {
+      getTurnData: jest.fn(() => mockTurnData),
+      getToVertex: jest.fn(() => ({ getID: () => 'vertex_123' })),
+      withTurnData: jest.fn().mockReturnThis()
+    };
+
+    const mockSegment = { id: 'segment_123' };
+    let mockStreet: any = null;
+
+    if (options.streetName !== undefined || options.signText !== undefined) {
+      mockStreet = {
+        getName: jest.fn(() => options.streetName),
+        getAttribute: jest.fn((attr) => {
+          if (attr === 'signText') return options.signText;
+          if (attr === 'signType') return options.signType;
+          return null;
+        })
+      };
+    }
+
+    return { mockTurn, mockTurnData, mockSegment, mockStreet };
+  }
+
+  it('should return turn unmodified if it already has turn guidance', () => {
+    const { mockTurn } = createMockTurn({ hasTurnGuidance: true });
+
+    const result = pullRoadshieldsMethod.application([mockTurn as any]);
+
+    expect(result[0]).toBe(mockTurn);
+    expect(mockGetSegmentByVertex).not.toHaveBeenCalled();
+  });
+
+  it('should return turn unmodified if street is null/undefined (e.g. streetless segment)', () => {
+    const { mockTurn, mockSegment } = createMockTurn({
+      hasTurnGuidance: false,
+      streetName: undefined // resulting in street being mock-returned as null
+    });
+
+    mockGetSegmentByVertex.mockReturnValue(mockSegment);
+    mockGetStreetBySegment.mockReturnValue(null);
+
+    const result = pullRoadshieldsMethod.application([mockTurn as any]);
+
+    expect(result[0]).toBe(mockTurn);
+    expect(mockTurn.withTurnData).not.toHaveBeenCalled();
+  });
+
+  it('should return turn unmodified if street has no signText (roadshield text)', () => {
+    const { mockTurn, mockSegment, mockStreet } = createMockTurn({
+      hasTurnGuidance: false,
+      streetName: 'Main St',
+      signText: null
+    });
+
+    mockGetSegmentByVertex.mockReturnValue(mockSegment);
+    mockGetStreetBySegment.mockReturnValue(mockStreet);
+
+    const result = pullRoadshieldsMethod.application([mockTurn as any]);
+
+    expect(result[0]).toBe(mockTurn);
+    expect(mockStreet.getAttribute).toHaveBeenCalledWith('signText');
+    expect(mockTurn.withTurnData).not.toHaveBeenCalled();
+  });
+
+  it('should return turn unmodified if street name is null/undefined', () => {
+    const { mockTurn, mockSegment, mockStreet } = createMockTurn({
+      hasTurnGuidance: false,
+      streetName: null,
+      signText: '99'
+    });
+
+    mockGetSegmentByVertex.mockReturnValue(mockSegment);
+    mockGetStreetBySegment.mockReturnValue(mockStreet);
+
+    const result = pullRoadshieldsMethod.application([mockTurn as any]);
+
+    expect(result[0]).toBe(mockTurn);
+    expect(mockStreet.getName).toHaveBeenCalled();
+    expect(mockTurn.withTurnData).not.toHaveBeenCalled();
+  });
+
+  it('should return turn unmodified if street name does not start with roadshield prefixes', () => {
+    const { mockTurn, mockSegment, mockStreet } = createMockTurn({
+      hasTurnGuidance: false,
+      streetName: 'Main St 99',
+      signText: '99'
+    });
+
+    mockGetSegmentByVertex.mockReturnValue(mockSegment);
+    mockGetStreetBySegment.mockReturnValue(mockStreet);
+
+    const result = pullRoadshieldsMethod.application([mockTurn as any]);
+
+    expect(result[0]).toBe(mockTurn);
+    expect(mockTurn.withTurnData).not.toHaveBeenCalled();
+  });
+
+  it('should apply turn guidance and trim name when street name starts with roadshield prefix', () => {
+    const { mockTurn, mockTurnData, mockSegment, mockStreet } = createMockTurn({
+      hasTurnGuidance: false,
+      streetName: 'To 99 Eastbound',
+      signText: '99',
+      signType: 2
+    });
+
+    mockGetSegmentByVertex.mockReturnValue(mockSegment);
+    mockGetStreetBySegment.mockReturnValue(mockStreet);
+
+    const result = pullRoadshieldsMethod.application([mockTurn as any]);
+
+    expect(mockCreateTurnGuidance).toHaveBeenCalledWith({
+      roadShields: {
+        'RS-0': {
+          type: 2,
+          text: '99'
+        }
+      },
+      visualInstruction: '$RS-0 Eastbound',
+      tts: '99 Eastbound'
+    });
+
+    expect(mockTurnData.withTurnGuidance).toHaveBeenCalled();
+    expect(mockTurn.withTurnData).toHaveBeenCalledWith(mockTurnData);
+    expect(result[0]).toBe(mockTurn);
+  });
+});

--- a/userscript/src/instruction-application-engine/methods/pull-roadshields-method.ts
+++ b/userscript/src/instruction-application-engine/methods/pull-roadshields-method.ts
@@ -1,6 +1,6 @@
 import { TurnInstructionMethod } from '@/instruction-application-engine/methods/turn-instruction-method';
 import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
-import { getSegmentByVertex } from '@/utils/location';
+import { getSegmentByVertex, getStreetBySegment } from '@/utils/location';
 import { createTurnGuidance } from '@/utils/wme-entities/turn-guidance';
 
 const prefixes = ['$RS$', 'To $RS$', 'ל$RS$', 'ל-$RS$', 'ל- $RS$', 'ל $RS$'];
@@ -18,16 +18,19 @@ const pullRoadshieldsMethod: TurnInstructionMethod = {
       if (turn.getTurnData().hasTurnGuidance()) return turn;
 
       const toSegment = getSegmentByVertex(dataModel, turn.getToVertex());
-      const toSegmentAddress = toSegment.getAddress();
-      const toSegmentStreet = toSegmentAddress.getStreet();
+      const toSegmentStreet = getStreetBySegment(dataModel, toSegment);
+      if (!toSegmentStreet) return turn;
+
       const roadshieldText = toSegmentStreet.getAttribute('signText');
       if (!roadshieldText) return turn;
+
+      const streetName = toSegmentStreet.getName();
+      if (!streetName) return turn;
+
       const potentialPrefixes = buildPrefixesWithRoadshield(roadshieldText);
       for (const potentialPrefix of potentialPrefixes) {
-        if (toSegmentStreet.getName().startsWith(potentialPrefix)) {
-          const trimSegmentName = toSegmentStreet
-            .getName()
-            .substring(potentialPrefix.length);
+        if (streetName.startsWith(potentialPrefix)) {
+          const trimSegmentName = streetName.substring(potentialPrefix.length);
 
           const turnData = turn.getTurnData().withTurnGuidance(
             createTurnGuidance({


### PR DESCRIPTION
## Description

This PR refactors `pullRoadshieldsMethod` to improve code safety, robustness, and reuse existing abstractions, resolving potential runtime `TypeError` crashes when processing unnamed or streetless segments in Waze Map Editor (WME).

### Key Changes
1. **API Safe Traversal (DRY)**:
   - Replaced manual, unsafe segment address/street traversal (`toSegment.getAddress().getStreet()`) with the existing codebase utility `getStreetBySegment(dataModel, toSegment)`.
   - Avoids calling `getAddress()` without its required `dataModel` argument, fixing a TypeScript contract violation.
2. **KISS & Robustness (Exception Prevention)**:
   - Added checks to return the turn unmodified if `toSegmentStreet` is null or undefined (e.g. roundabout, parking lot, or ramp segments with no primary street).
   - Added checks to return the turn unmodified if `streetName` is null or undefined, preventing crashes when checking `.startsWith()` or `.substring()` on unnamed segments.
3. **Jest Unit Tests**:
   - Added `pull-roadshields-method.spec.ts` with comprehensive unit tests checking early-outs, matching/trimming logic, and safety checks under mocked model parameters.
   - Updated `jest.config.json` with `moduleNameMapper` to support `@/` absolute alias paths in Jest tests.

## Verification

### Automated Tests
Ran `npm test` successfully (all 26 tests passed):
```bash
PASS src/instruction-application-engine/methods/pull-roadshields-method.spec.ts
```

### Build Check
Ran `npm run build` successfully to verify webpack compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for the roadshield extraction method, covering edge cases and validation scenarios including missing data and successful extraction workflows.

* **Bug Fixes**
  * Improved roadshield extraction robustness by implementing additional validation guards for street data and sign information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->