### PR TITLE
feat: integrate logstream with logs exporting

### DIFF
--- a/userscript/package-lock.json
+++ b/userscript/package-lock.json
@@ -9,8 +9,10 @@
       "version": "2.4.0",
       "license": "ISC",
       "dependencies": {
+        "@editor-x/wme-logstream": "^0.1.0-alpha.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
+        "@TheEditorX/wme-logstream": "npm:@editor-x/wme-logstream@^0.1.0-alpha.1",
         "@tippyjs/react": "^4.2.6",
         "@turf/buffer": "^7.3.5",
         "@turf/center": "^6.5.0",
@@ -1966,6 +1968,22 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@dmsnell/diff-match-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+      "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@editor-x/wme-logstream": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@editor-x/wme-logstream/-/wme-logstream-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-1lpAtdotx+LySvuOgTx45tUxj0QaK7YEU0/6i7aGHKyMzKRQfWOJ8askXYj6fajXS7FjDA2//XUxM0UhuYvkrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "jsondiffpatch": "^0.7.6"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -2859,6 +2877,17 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@TheEditorX/wme-logstream": {
+      "name": "@editor-x/wme-logstream",
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@editor-x/wme-logstream/-/wme-logstream-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-1lpAtdotx+LySvuOgTx45tUxj0QaK7YEU0/6i7aGHKyMzKRQfWOJ8askXYj6fajXS7FjDA2//XUxM0UhuYvkrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "jsondiffpatch": "^0.7.6"
       }
     },
     "node_modules/@tippyjs/react": {
@@ -6003,6 +6032,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8113,6 +8148,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+      "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dmsnell/diff-match-patch": "^1.1.0"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/jsts": {

--- a/userscript/package-lock.json
+++ b/userscript/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.4.0",
       "license": "ISC",
       "dependencies": {
-        "@editor-x/wme-logstream": "^0.1.0-alpha.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
         "@TheEditorX/wme-logstream": "npm:@editor-x/wme-logstream@^0.1.0-alpha.1",
@@ -22,7 +21,6 @@
         "axios": "^1.6.8",
         "clsx": "^2.1.0",
         "deepmerge": "^4.3.1",
-        "nanoid": "^3.3.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^6.22.3",
@@ -1973,16 +1971,6 @@
       "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
       "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@editor-x/wme-logstream": {
-      "version": "0.1.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@editor-x/wme-logstream/-/wme-logstream-0.1.0-alpha.1.tgz",
-      "integrity": "sha512-1lpAtdotx+LySvuOgTx45tUxj0QaK7YEU0/6i7aGHKyMzKRQfWOJ8askXYj6fajXS7FjDA2//XUxM0UhuYvkrw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "fflate": "^0.8.3",
-        "jsondiffpatch": "^0.7.6"
-      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
@@ -8467,24 +8455,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/userscript/package.json
+++ b/userscript/package.json
@@ -46,6 +46,8 @@
     "wme-sdk-typings": "https://www.waze.com/editor/sdk/wme-sdk-typings.tgz"
   },
   "dependencies": {
+    "@editor-x/wme-logstream": "^0.1.0-alpha.1",
+    "@TheEditorX/wme-logstream": "npm:@editor-x/wme-logstream@^0.1.0-alpha.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@tippyjs/react": "^4.2.6",

--- a/userscript/package.json
+++ b/userscript/package.json
@@ -46,10 +46,9 @@
     "wme-sdk-typings": "https://www.waze.com/editor/sdk/wme-sdk-typings.tgz"
   },
   "dependencies": {
-    "@editor-x/wme-logstream": "^0.1.0-alpha.1",
-    "@TheEditorX/wme-logstream": "npm:@editor-x/wme-logstream@^0.1.0-alpha.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
+    "@TheEditorX/wme-logstream": "npm:@editor-x/wme-logstream@^0.1.0-alpha.1",
     "@tippyjs/react": "^4.2.6",
     "@turf/buffer": "^7.3.5",
     "@turf/center": "^6.5.0",
@@ -59,7 +58,6 @@
     "axios": "^1.6.8",
     "clsx": "^2.1.0",
     "deepmerge": "^4.3.1",
-    "nanoid": "^3.3.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.22.3",

--- a/userscript/src/components/preferences/Preferences.tsx
+++ b/userscript/src/components/preferences/Preferences.tsx
@@ -5,6 +5,7 @@ import { getWazeMapEditorWindow } from '@/utils/get-wme-window';
 import { usePreference, useSidebarTabPane } from '@/hooks';
 import { createPortal } from 'react-dom';
 import { PreferencesContent } from './PreferencesContent';
+import { showDebugMenu } from '@/utils/debug-menu';
 
 export function Preferences() {
   const [showPreferences, setShowPreferences] = useState(false);
@@ -20,11 +21,33 @@ export function Preferences() {
     scriptTab.tabLabel.innerText = 'JBU';
     setScriptTabPane(scriptTab.tabPane);
 
+    let clickCount = 0;
+    let lastClickTime = 0;
+    const CLICK_TIMEOUT = 3000;
+
+    const handlePointerUp = (event: MouseEvent) => {
+      const currentTime = Date.now();
+      if (currentTime - lastClickTime > CLICK_TIMEOUT) {
+        clickCount = 0;
+      }
+      clickCount++;
+      lastClickTime = currentTime;
+
+      if (clickCount === 5) {
+        clickCount = 0;
+        showDebugMenu(event);
+      }
+    };
+
+    const tabLabel = scriptTab.tabLabel;
+    tabLabel.addEventListener('pointerup', handlePointerUp);
+
     return () => {
+      tabLabel.removeEventListener('pointerup', handlePointerUp);
       W.userscripts.removeSidebarTab(process.env.SCRIPT_ID);
       setScriptTabPane(null);
     };
-  }, [prefsLocation])
+  }, [prefsLocation]);
 
   const targetElement = (() => {
     switch (prefsLocation) {
@@ -33,16 +56,25 @@ export function Preferences() {
     }
   })();
 
-  return targetElement ? createPortal(
-    <>
-      {prefsLocation === 'wme-prefs' && (
-        <PreferencesEntryCard onClick={setShowPreferences.bind(null, true)} />
-      )}
-      {showPreferences && prefsLocation === 'wme-prefs' && (
-        <PreferencesList onClosed={setShowPreferences.bind(null, false)} />
-      )}
-      {prefsLocation === 'tab' && <PreferencesContent />}
-    </>,
-    targetElement,
-  ) : null;
+  const handleContextMenu = (event: React.MouseEvent) => {
+    showDebugMenu(event.nativeEvent);
+  };
+
+  return targetElement
+    ? createPortal(
+        <>
+          {prefsLocation === 'wme-prefs' && (
+            <PreferencesEntryCard
+              onClick={setShowPreferences.bind(null, true)}
+              onContextMenu={handleContextMenu}
+            />
+          )}
+          {showPreferences && prefsLocation === 'wme-prefs' && (
+            <PreferencesList onClosed={setShowPreferences.bind(null, false)} />
+          )}
+          {prefsLocation === 'tab' && <PreferencesContent />}
+        </>,
+        targetElement,
+      )
+    : null;
 }

--- a/userscript/src/components/preferences/PreferencesEntryCard.tsx
+++ b/userscript/src/components/preferences/PreferencesEntryCard.tsx
@@ -5,8 +5,12 @@ import { ListItemCard } from '../ListItemCard';
 
 interface PreferencesEntryCardProps {
   onClick?: MouseEventHandler;
+  onContextMenu?: MouseEventHandler;
 }
-export function PreferencesEntryCard({ onClick }: PreferencesEntryCardProps) {
+export function PreferencesEntryCard({
+  onClick,
+  onContextMenu,
+}: PreferencesEntryCardProps) {
   const t = useTranslate();
 
   return (
@@ -20,6 +24,7 @@ export function PreferencesEntryCard({ onClick }: PreferencesEntryCardProps) {
         justifySelf: 'end',
       }}
       onClick={onClick}
+      onContextMenu={onContextMenu}
     >
       <div className="list-item-card-title">{process.env.SCRIPT_NAME}</div>
       <WzCaption>{t('jb_utils.user.prefs.card_helper_text')}</WzCaption>

--- a/userscript/src/logger.ts
+++ b/userscript/src/logger.ts
@@ -2,6 +2,9 @@ import { LogStream } from '@TheEditorX/wme-logstream';
 
 export const logStream = LogStream.create({
   minLogLevel: 'DEBUG',
+  persist: true,
+  dbPrefix: process.env.SCRIPT_ID.replace('/', '-'),
+  scriptVersion: process.env.VERSION,
   brand: {
     scriptPrefix: process.env.SCRIPT_NAME ?? 'Junction Box Utils',
   },

--- a/userscript/src/logger.ts
+++ b/userscript/src/logger.ts
@@ -1,41 +1,75 @@
+import { LogStream } from '@TheEditorX/wme-logstream';
+
+export const logStream = LogStream.create({
+  minLogLevel: 'DEBUG',
+  brand: {
+    scriptPrefix: process.env.SCRIPT_NAME ?? 'Junction Box Utils',
+  },
+});
+
+function formatLogStreamArgs(args: any[]): { message: string; data?: any } {
+  if (args.length === 0) {
+    return { message: '' };
+  }
+  if (typeof args[0] === 'string') {
+    const message = args[0];
+    if (args.length === 2) {
+      return { message, data: args[1] };
+    } else if (args.length > 2) {
+      return { message, data: args.slice(1) };
+    }
+    return { message };
+  }
+  if (args.length === 1) {
+    return { message: '', data: args[0] };
+  }
+  return { message: '', data: args };
+}
+
+/**
+ * @deprecated Use `logStream` from `@/logger` (or `@TheEditorX/wme-logstream`) instead.
+ */
 // noinspection JSUnusedGlobalSymbols
 export class Logger {
-  private static get displayName() {
-    return process.env.SCRIPT_NAME;
+  /**
+   * @deprecated Use `logStream.info()` instead.
+   */
+  static log(...args: any[]) {
+    const { message, data } = formatLogStreamArgs(args);
+    logStream.info(message, data);
   }
 
-  private static addDisplayNameToDataComponent(message: string | null) {
-    const prefix = `[${Logger.displayName}]`;
-    if (!message) return prefix;
-    return `${prefix} ${message}`;
+  /**
+   * @deprecated Use `logStream.info()` instead.
+   */
+  static info(...args: any[]) {
+    const { message, data } = formatLogStreamArgs(args);
+    logStream.info(message, data);
   }
 
-  private static formatData(...args: any[]): [string, ...any] {
-    if (args.length === 0) return null;
-    if (typeof args[0] === 'string') {
-      const [textArgument, ...rest] = args;
-      return [this.addDisplayNameToDataComponent(textArgument), ...rest];
-    }
-
-    return [this.addDisplayNameToDataComponent(null), ...args];
+  /**
+   * @deprecated Use `logStream.warn()` instead.
+   */
+  static warn(...args: any[]) {
+    const { message, data } = formatLogStreamArgs(args);
+    logStream.warn(message, data);
   }
 
-  private static logLevel(level: string, ...data: any[]) {
-    if (typeof console[level] !== 'function') {
-      throw new Error(`Logging level "${level}" is not supported`);
-    }
-
-    const formattedData = Logger.formatData(...data);
-    return console[level](...formattedData);
+  /**
+   * @deprecated Use `logStream.error()` instead.
+   */
+  static error(...args: any[]) {
+    const { message, data } = formatLogStreamArgs(args);
+    logStream.error(message, data);
   }
 
-  private static bindLogLevel(level: string) {
-    return (...data: any[]) => this.logLevel(level, ...data);
+  /**
+   * @deprecated Use `logStream.debug()` instead.
+   */
+  static debug(...args: any[]) {
+    const { message, data } = formatLogStreamArgs(args);
+    logStream.debug(message, data);
   }
-
-  static log = Logger.bindLogLevel('log');
-  static warn = Logger.bindLogLevel('warn');
-  static error = Logger.bindLogLevel('error');
-  static info = Logger.bindLogLevel('info');
-  static debug = Logger.bindLogLevel('debug');
 }
+
+export { LogStream };

--- a/userscript/src/utils/debug-menu.ts
+++ b/userscript/src/utils/debug-menu.ts
@@ -1,0 +1,57 @@
+import { logStream } from '@/logger';
+
+export interface WzMenuElement extends HTMLElement {
+  showMenu(event: MouseEvent | PointerEvent): void;
+}
+
+export function showDebugMenu(event: MouseEvent) {
+  event.preventDefault();
+
+  let menu = document.querySelector(
+    'wz-menu#wme-jb-utils-debug-menu',
+  ) as WzMenuElement;
+
+  if (!menu) {
+    menu = document.createElement('wz-menu') as WzMenuElement;
+    menu.id = 'wme-jb-utils-debug-menu';
+    menu.setAttribute('fixed', 'true');
+
+    // Create menu items
+    const downloadLogsItem = document.createElement('wz-menu-item');
+    downloadLogsItem.innerHTML = 'Download Logs';
+    downloadLogsItem.addEventListener('click', () => {
+      logStream.debug('Downloading logs via debug menu...');
+      logStream
+        .downloadLogs(
+          `wme-junction-box-utils-logs-${new Date().toISOString()}.xlog`,
+        )
+        .catch((err) => {
+          logStream.error('Failed to download logs', err);
+        });
+    });
+
+    // Add divider before version info
+    const divider = document.createElement('wz-menu-divider');
+
+    // Create debug info item (non-clickable)
+    const debugInfoItem = document.createElement('div');
+    debugInfoItem.style.padding =
+      'var(--wz-menu-option-padding, var(--space-always-s, 12px))';
+    debugInfoItem.style.minHeight =
+      'var(--wz-menu-option-height, var(--wz-option-height, 40px))';
+    debugInfoItem.innerHTML = `
+      <wz-overline>${process.env.SCRIPT_NAME} Debug Menu</wz-overline>
+      <div style="display: flex; flex-direction: column">
+        <wz-caption>Version: ${process.env.VERSION}</wz-caption>
+      </div>
+    `;
+
+    menu.appendChild(downloadLogsItem);
+    menu.appendChild(divider);
+    menu.appendChild(debugInfoItem);
+
+    document.body.appendChild(menu);
+  }
+
+  menu.showMenu(event);
+}

--- a/userscript/webpack.config.js
+++ b/userscript/webpack.config.js
@@ -5,7 +5,6 @@ const { DefinePlugin } = require('webpack');
 const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const WebpackUserscriptPlugin = require('webpack-userscript').default;
-const { nanoid } = require('nanoid');
 
 function getPurePackageName() {
   const { name } = packageInfo;
@@ -31,7 +30,9 @@ module.exports = () => {
     plugins: [
       new DefinePlugin({
         'process.env.VERSION': JSON.stringify(packageInfo.version),
-        'process.env.SCRIPT_ID': JSON.stringify(nanoid()),
+        'process.env.SCRIPT_ID': JSON.stringify(
+          `${packageInfo.author}/${getPurePackageName()}`,
+        ),
         'process.env.SCRIPT_FULL_NAME': JSON.stringify(
           packageInfo.fullDisplayName,
         ),


### PR DESCRIPTION
This pull request introduces a new debug menu for the preferences UI, refactors the logging system to use a new `LogStream`-based logger, and updates dependencies to support the new logging features. The debug menu allows users to download logs directly from the UI, and the logging refactor replaces the previous `Logger` implementation with a more flexible and persistent log stream. Several new packages are added to support log streaming and diffing functionality.

### Debug Menu Feature

* Added a debug menu accessible via right-click or five pointer clicks on the preferences tab label, allowing users to download logs and view version info

### Logging Refactor

* Replaced the old `Logger` class with a new `logStream` implementation using `@TheEditorX/wme-logstream`, providing persistent and structured logging with support for downloading logs.

### Dependency Updates

* Added `@TheEditorX/wme-logstream` and underlying dependencies `fflate`, `jsondiffpatch`, and `@dmsnell/diff-match-patch` as dependencies to support log streaming and diffing features

### Build/Config Changes

* Updated the Webpack config to use a deterministic `SCRIPT_ID` based on author and package name, instead of a random value (`userscript/webpack.config.js`).

These changes improve debugging capabilities for users and developers, modernize logging infrastructure, and ensure logs can be easily persisted and retrieved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-demand debug menu with log download and version information.
  * Added multiple access methods for the debug menu from the Preferences screen, including a rapid multi-click gesture and context menu.
  * Improved logging support for diagnostic information.

* **Bug Fixes**
  * Debug menu events are handled cleanly without affecting normal menu interactions.
  * Existing debug menu instances are reused instead of creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->